### PR TITLE
Fix ReferenceTrimmer on Linux

### DIFF
--- a/src/ReferenceTrimmerTask.cs
+++ b/src/ReferenceTrimmerTask.cs
@@ -185,7 +185,7 @@ namespace ReferenceTrimmer
                     .Where(path => !path.EndsWith("_._", StringComparison.Ordinal)) // Ignore special packages
                     .Select(path =>
                     {
-                        var packageFolderRelativePath = Path.Combine(nugetLibrary.Name, nugetLibrary.Version.ToNormalizedString(), path);
+                        var packageFolderRelativePath = Path.Combine(nugetLibrary.Name.ToLowerInvariant(), nugetLibrary.Version.ToNormalizedString(), path);
                         var fullPath = packageFolders
                             .Select(packageFolder => Path.Combine(packageFolder, packageFolderRelativePath))
                             .First(File.Exists);

--- a/src/ReferenceTrimmerTask.cs
+++ b/src/ReferenceTrimmerTask.cs
@@ -180,12 +180,13 @@ namespace ReferenceTrimmer
             // Get the transitive closure of assemblies included by each package
             foreach (var nugetLibrary in nugetLibraries)
             {
+                string nugetLibraryPath = lockFile.GetLibrary(nugetLibrary.Name, nugetLibrary.Version).Path;
                 List<string> nugetLibraryAssemblies = nugetLibrary.CompileTimeAssemblies
                     .Select(item => item.Path)
                     .Where(path => !path.EndsWith("_._", StringComparison.Ordinal)) // Ignore special packages
                     .Select(path =>
                     {
-                        var packageFolderRelativePath = Path.Combine(nugetLibrary.Name.ToLowerInvariant(), nugetLibrary.Version.ToNormalizedString(), path);
+                        var packageFolderRelativePath = Path.Combine(nugetLibraryPath, path);
                         var fullPath = packageFolders
                             .Select(packageFolder => Path.Combine(packageFolder, packageFolderRelativePath))
                             .First(File.Exists);

--- a/test/E2ETests.cs
+++ b/test/E2ETests.cs
@@ -48,7 +48,7 @@ public sealed class E2ETests
     public void UsedProjectReference()
     {
         RunMSBuild(
-            projectFile: @"Library\Library.csproj",
+            projectFile: @"Library/Library.csproj",
             expectedWarnings: Array.Empty<string>());
     }
 
@@ -56,10 +56,10 @@ public sealed class E2ETests
     public void UnusedProjectReference()
     {
         RunMSBuild(
-            projectFile: @"Library\Library.csproj",
+            projectFile: @"Library/Library.csproj",
             expectedWarnings: new[]
             {
-                @"ProjectReference ..\Dependency\Dependency.csproj can be removed",
+                @"ProjectReference ../Dependency/Dependency.csproj can be removed",
             });
     }
 
@@ -68,11 +68,11 @@ public sealed class E2ETests
     {
         // For direct references, MSBuild can't determine build order so we need to ensure the dependency is already built
         RunMSBuild(
-            projectFile: @"Dependency\Dependency.csproj",
+            projectFile: @"Dependency/Dependency.csproj",
             expectedWarnings: Array.Empty<string>());
 
         RunMSBuild(
-            projectFile: @"Library\Library.csproj",
+            projectFile: @"Library/Library.csproj",
             expectedWarnings: Array.Empty<string>());
     }
 
@@ -81,11 +81,11 @@ public sealed class E2ETests
     {
         // For direct references, MSBuild can't determine build order so we need to ensure the dependency is already built
         RunMSBuild(
-            projectFile: @"Dependency\Dependency.csproj",
+            projectFile: @"Dependency/Dependency.csproj",
             expectedWarnings: Array.Empty<string>());
 
         RunMSBuild(
-            projectFile: @"Library\Library.csproj",
+            projectFile: @"Library/Library.csproj",
             expectedWarnings: new[]
             {
                 @"Reference Dependency can be removed",
@@ -96,7 +96,7 @@ public sealed class E2ETests
     public void UsedPackageReference()
     {
         RunMSBuild(
-            projectFile: @"Library\Library.csproj",
+            projectFile: @"Library/Library.csproj",
             expectedWarnings: Array.Empty<string>());
     }
 
@@ -104,7 +104,7 @@ public sealed class E2ETests
     public void UsedIndirectPackageReference()
     {
         RunMSBuild(
-            projectFile: @"WebHost\WebHost.csproj",
+            projectFile: @"WebHost/WebHost.csproj",
             expectedWarnings: Array.Empty<string>());
     }
 
@@ -112,7 +112,7 @@ public sealed class E2ETests
     public void UnusedPackageReference()
     {
         RunMSBuild(
-            projectFile: @"Library\Library.csproj",
+            projectFile: @"Library/Library.csproj",
             expectedWarnings: new[]
             {
                 @"PackageReference Newtonsoft.Json can be removed",
@@ -123,7 +123,7 @@ public sealed class E2ETests
     public void UnusedPackageReferenceDocDisabled()
     {
         RunMSBuild(
-            projectFile: @"Library\Library.csproj",
+            projectFile: @"Library/Library.csproj",
             expectedWarnings: new[]
             {
                 @"Enable /doc parameter or in MSBuild set <GenerateDocumentationFile>true</GenerateDocumentationFile> for accuracy of used references detection",
@@ -134,7 +134,7 @@ public sealed class E2ETests
     public void MissingReferenceSourceTarget()
     {
         RunMSBuild(
-            projectFile: @"Library\Library.csproj",
+            projectFile: @"Library/Library.csproj",
             expectedWarnings: Array.Empty<string>());
     }
 
@@ -142,7 +142,7 @@ public sealed class E2ETests
     public void PlatformPackageConflictResolution()
     {
         RunMSBuild(
-            projectFile: @"Library\Library.csproj",
+            projectFile: @"Library/Library.csproj",
             expectedWarnings: new[]
             {
                 // TODO: These "metapackages" should not be reported.
@@ -163,7 +163,7 @@ public sealed class E2ETests
                 string vsAppIdeDir = Environment.GetEnvironmentVariable("VSAPPIDDIR");
                 if (!string.IsNullOrEmpty(vsAppIdeDir))
                 {
-                    vsInstallDir = Path.Combine(vsAppIdeDir, @"..\..");
+                    vsInstallDir = Path.Combine(vsAppIdeDir, "..", "..");
                 }
             }
 

--- a/test/TestData/MissingReferenceSourceTarget/Library/Library.csproj
+++ b/test/TestData/MissingReferenceSourceTarget/Library/Library.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Dependency\Dependency.csproj" />
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/TestData/UnusedProjectReference/Library/Library.csproj
+++ b/test/TestData/UnusedProjectReference/Library/Library.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Dependency\Dependency.csproj" />
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/TestData/UsedProjectReference/Library/Library.csproj
+++ b/test/TestData/UsedProjectReference/Library/Library.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Dependency\Dependency.csproj" />
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes the `Sequence contains no matching element` observed on Linux machines.