### PR TITLE
Disable shared compilation in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ./TestResults
+          files: '*.cobertura.xml'
 
       - name: Upload test results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,6 +31,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ./TestResults
+          files: '*.cobertura.xml'
 
       - name: Upload test results
         uses: actions/upload-artifact@v3

--- a/test/E2ETests.cs
+++ b/test/E2ETests.cs
@@ -31,6 +31,8 @@ public sealed class E2ETests
     <!-- Per https://github.com/dotnet/roslyn/issues/66188 /doc param is required for accurate results -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
+    <!-- Ensure always instrumented binaries are used for code coverage -->
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
   <ItemGroup>
     <Analyzer Include=""{testOutputDir}\ReferenceTrimmerAnalyzer.dll""/>


### PR DESCRIPTION
Local `dotnet test --collect "Code Coverage"` runs get CC % numbers for the Analyzer dll only for the first run. Subsequent runs do not get the coverage numbers, as the shared compiler is reusing the dll. Disabling the shared compilation gets CC % for each local test run.