### PR TITLE
Fix UTs: Put task assemblies in subdir to avoid loading other assemblies adjacent to the test assembly

### DIFF
--- a/test/E2ETests.cs
+++ b/test/E2ETests.cs
@@ -27,7 +27,7 @@ public sealed class E2ETests
             Path.Combine(testContext.TestRunDirectory, "Directory.Build.props"),
             $@"<Project>
   <PropertyGroup>
-    <ReferenceTrimmerTaskAssembly>{testOutputDir}\ReferenceTrimmer.dll</ReferenceTrimmerTaskAssembly>
+    <ReferenceTrimmerTaskAssembly>{testOutputDir}\ReferenceTrimmer\ReferenceTrimmer.dll</ReferenceTrimmerTaskAssembly>
     <!-- Per https://github.com/dotnet/roslyn/issues/66188 /doc param is required for accurate results -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
@@ -35,14 +35,14 @@ public sealed class E2ETests
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
   <ItemGroup>
-    <Analyzer Include=""{testOutputDir}\ReferenceTrimmerAnalyzer.dll""/>
+    <Analyzer Include=""{testOutputDir}\ReferenceTrimmer\ReferenceTrimmerAnalyzer.dll""/>
   </ItemGroup>
-  <Import Project=""{testOutputDir}\build\ReferenceTrimmer.props"" />
+  <Import Project=""{testOutputDir}\ReferenceTrimmer\build\ReferenceTrimmer.props"" />
 </Project>");
         File.WriteAllText(
             Path.Combine(testContext.TestRunDirectory, "Directory.Build.targets"),
             $@"<Project>
-  <Import Project=""{testOutputDir}\build\ReferenceTrimmer.targets"" />
+  <Import Project=""{testOutputDir}\ReferenceTrimmer\build\ReferenceTrimmer.targets"" />
 </Project>");
     }
 

--- a/test/ReferenceTrimmer.Tests.csproj
+++ b/test/ReferenceTrimmer.Tests.csproj
@@ -10,12 +10,36 @@
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\src\ReferenceTrimmer.csproj" />
-    <ProjectReference Include="..\analyzer\ReferenceTrimmerAnalyzer.csproj" />
+    <ProjectReference Include="..\src\ReferenceTrimmer.csproj">
+      <OutputItemType>ReferenceTrimmerTargetPath</OutputItemType>
+    </ProjectReference>
+    <ProjectReference Include="..\analyzer\ReferenceTrimmerAnalyzer.csproj">
+      <OutputItemType>ReferenceTrimmerAnalyzerTargetPath</OutputItemType>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestData\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <!-- Use the task's outputs for e2e tests -->
+  <Target Name="GetReferenceTrimmerOutputs"
+          DependsOnTargets="ResolveProjectReferences">
+    <PropertyGroup>
+      <ReferenceTrimmerOutputPath>@(ReferenceTrimmerTargetPath -> '%(RootDir)%(Directory)')</ReferenceTrimmerOutputPath>
+      <ReferenceTrimmerAnalyzerOutputPath>@(ReferenceTrimmerAnalyzerTargetPath -> '%(RootDir)%(Directory)')</ReferenceTrimmerAnalyzerOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <ReferenceTrimmerOutputs Include="$(ReferenceTrimmerOutputPath)\**" />
+      <ReferenceTrimmerOutputs Include="$(ReferenceTrimmerAnalyzerOutputPath)\**" />
+    </ItemGroup>
+  </Target>
+  <Target Name="CopyReferenceTrimmerOutputs"
+          AfterTargets="AfterBuild"
+          DependsOnTargets="GetReferenceTrimmerOutputs"
+          Inputs="@(ReferenceTrimmerOutputs)"
+          Outputs="@(ReferenceTrimmerOutputs -> '$(OutputPath)\ReferenceTrimmer\%(RecursiveDir)%(Filename)%(Extension)')">
+    <Copy SourceFiles="@(ReferenceTrimmerOutputs)"
+          DestinationFiles="@(ReferenceTrimmerOutputs -> '$(OutputPath)\ReferenceTrimmer\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
 </Project>


### PR DESCRIPTION
This fixes the following error when running locally:

```
The "ReferenceTrimmerTask" task failed unexpectedly.
System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
File name: 'System.Runtime, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at ReferenceTrimmer.ReferenceTrimmerTask.GetPackageInfos()
   at ReferenceTrimmer.ReferenceTrimmerTask.Execute() in C:\Users\David\Code\ReferenceTrimmer\src\ReferenceTrimmerTask.cs:line 52
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()
```