### PR TITLE
Remove dependency on System.Text.Json

### DIFF
--- a/src/Analyzer/ReferenceTrimmer.Analyzer.csproj
+++ b/src/Analyzer/ReferenceTrimmer.Analyzer.csproj
@@ -10,24 +10,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" Version="3.10" />
   </ItemGroup>
   <ItemGroup>
-    <!-- Dependencies -->
-    <PackageReference Include="System.Text.Json" Version="7.0.2" GeneratePathProperty="true" PrivateAssets="all" />
-    <!-- Indirect dependencies -->
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\Shared\*.cs" />
   </ItemGroup>
-  <PropertyGroup>
-    <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
-  </PropertyGroup>
-
-  <Target Name="GetDependencyTargetPaths">
-    <ItemGroup>
-      <TargetPathWithTargetPlatformMoniker Include="$(PkgSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" IncludeRuntimeDependency="false" />
-      <TargetPathWithTargetPlatformMoniker Include="$(PkgMicrosoft_Bcl_AsyncInterfaces)\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll" IncludeRuntimeDependency="false" />
-      <TargetPathWithTargetPlatformMoniker Include="$(PkgSystem_Text_Encodings_Web)\lib\netstandard2.0\System.Text.Encodings.Web.dll" IncludeRuntimeDependency="false" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Immutable;
 using System.Reflection;
-using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using ReferenceTrimmer.Shared;
@@ -10,7 +9,7 @@ namespace ReferenceTrimmer.Analyzer;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
 {
-    private const string DeclaredReferencesFileName = "_ReferenceTrimmer_DeclaredReferences.json";
+    private const string DeclaredReferencesFileName = "_ReferenceTrimmer_DeclaredReferences.tsv";
 
     private static readonly DiagnosticDescriptor RT0000Descriptor = new(
         "RT0000",
@@ -146,7 +145,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
         {
             if (Path.GetFileName(additionalText.Path).Equals(DeclaredReferencesFileName, StringComparison.Ordinal))
             {
-                return JsonSerializer.Deserialize<DeclaredReferences>(File.ReadAllText(additionalText.Path));
+                return DeclaredReferences.ReadFromFile(additionalText.Path);
             }
         }
 

--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -8,7 +8,7 @@
 
   <Target Name="CollectDeclaredReferences" DependsOnTargets="ResolveProjectReferences">
     <PropertyGroup>
-      <_ReferenceTrimmerDeclaredReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_DeclaredReferences.json</_ReferenceTrimmerDeclaredReferencesFile>
+      <_ReferenceTrimmerDeclaredReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_DeclaredReferences.tsv</_ReferenceTrimmerDeclaredReferencesFile>
     </PropertyGroup>
     <ItemGroup>
       <!--

--- a/src/Shared/DeclaredReferences.cs
+++ b/src/Shared/DeclaredReferences.cs
@@ -1,6 +1,67 @@
 ﻿namespace ReferenceTrimmer.Shared;
 
-internal record DeclaredReferences(IReadOnlyList<DeclaredReference> References);
+internal record DeclaredReferences(IReadOnlyList<DeclaredReference> References)
+{
+    private const char FieldDelimiter = '\t';
+
+    private static readonly char[] FieldDelimiters = new[] { FieldDelimiter };
+
+    private static readonly Dictionary<DeclaredReferenceKind, string> KindEnumToString = new()
+    {
+        { DeclaredReferenceKind.Reference, nameof(DeclaredReferenceKind.Reference) },
+        { DeclaredReferenceKind.ProjectReference, nameof(DeclaredReferenceKind.ProjectReference) },
+        { DeclaredReferenceKind.PackageReference, nameof(DeclaredReferenceKind.PackageReference) },
+    };
+
+    private static readonly Dictionary<string, DeclaredReferenceKind> KindStringToEnum = new()
+    {
+        { nameof(DeclaredReferenceKind.Reference), DeclaredReferenceKind.Reference },
+        { nameof(DeclaredReferenceKind.ProjectReference), DeclaredReferenceKind.ProjectReference },
+        { nameof(DeclaredReferenceKind.PackageReference), DeclaredReferenceKind.PackageReference },
+    };
+
+    public void SaveToFile(string filePath)
+    {
+        using FileStream stream = File.Create(filePath);
+        using StreamWriter writer = new(stream);
+
+        foreach (DeclaredReference reference in References)
+        {
+            writer.Write(reference.AssemblyName);
+            writer.Write(FieldDelimiter);
+            writer.Write(KindEnumToString[reference.Kind]);
+            writer.Write(FieldDelimiter);
+            writer.Write(reference.Spec);
+            writer.WriteLine();
+        }
+    }
+
+    public static DeclaredReferences ReadFromFile(string filePath)
+    {
+        List<DeclaredReference> references = new();
+
+        using FileStream stream = File.OpenRead(filePath);
+        using StreamReader reader = new(stream);
+
+        string line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            string[] parts = line.Split(FieldDelimiters, 3);
+            if (parts.Length != 3)
+            {
+                throw new InvalidDataException($"File '{filePath}' is invalid. Line: {references.Count + 1}");
+            }
+
+            string assemblyName = parts[0];
+            DeclaredReferenceKind kind = KindStringToEnum[parts[1]];
+            string spec = parts[2];
+            DeclaredReference reference = new(assemblyName, kind, spec);
+            references.Add(reference);
+        }
+
+        return new DeclaredReferences(references);
+    }
+}
 
 internal record DeclaredReference(string AssemblyName, DeclaredReferenceKind Kind, string Spec);
 

--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Text.Json;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using NuGet.Common;
@@ -156,10 +155,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                 }
             }
 
-            using (FileStream stream = File.Create(OutputFile))
-            {
-                JsonSerializer.Serialize(stream, new DeclaredReferences(declaredReferences));
-            }
+            new DeclaredReferences(declaredReferences).SaveToFile(OutputFile);
         }
         finally
         {

--- a/src/Tasks/ReferenceTrimmer.Tasks.csproj
+++ b/src/Tasks/ReferenceTrimmer.Tasks.csproj
@@ -5,7 +5,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.1" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.3.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Shared\*.cs" />


### PR DESCRIPTION
Fixes #56 

This removes System.Text.Json in favor of just manually serializing/deserializing a tsv. Including dependencies in an analyzer, and to a lesser extent an MSBuild task, causes problems. Additionally, the data is fairly straightforward and not intended for human interaction so nothing fancy is needed anyway.

tsv was chosen so that it's human readable for debugging purposes and tabs should not be part of the data which avoid edge cases.