### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
   # Allow manually triggering
   workflow_dispatch:
 
@@ -14,7 +14,6 @@ jobs:
     # TODO: Add ubuntu-latest
     runs-on: windows-latest
     steps:
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Git Versioning requires a non-shallow clone
@@ -35,7 +34,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ./TestResults
-          files: '*.cobertura.xml'
+          files: "*.cobertura.xml"
 
       - name: Upload test results
         uses: actions/upload-artifact@v3
@@ -56,6 +55,7 @@ jobs:
         with:
           name: artifacts
           path: ./artifacts
+        if: ${{ always() }} # Always run this step even on failure
 
       - name: Push NuGet package
         run: dotnet nuget push artifacts\*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,10 +9,9 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-latest ]
+        os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Git Versioning requires a non-shallow clone
@@ -33,7 +32,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ./TestResults
-          files: '*.cobertura.xml'
+          files: "*.cobertura.xml"
 
       - name: Upload test results
         uses: actions/upload-artifact@v3
@@ -54,3 +53,4 @@ jobs:
         with:
           name: artifacts
           path: ./artifacts
+        if: ${{ always() }} # Always run this step even on failure

--- a/src/E2ETests/ReferenceTrimmer.E2ETests.csproj
+++ b/src/E2ETests/ReferenceTrimmer.E2ETests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Package\ReferenceTrimmer.Package.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <Targets>Build;Pack</Targets>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The tests project needs to depend on the packaging project's "Pack" target instead of just the "Build" target. Otherwise the packaging may not have happened yet, leading to the test project not copying the nupkg properly.