### PR TITLE
Check if reference trimmer is disabled before logging warnings

### DIFF
--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -62,6 +62,13 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
 
     private static void DumpUsedReferences(CompilationAnalysisContext context)
     {
+        DeclaredReferences? declaredReferences = GetDeclaredReferences(context);
+        if (declaredReferences == null)
+        {
+            // Reference Trimmer is disabled
+            return;
+        }
+
         Compilation compilation = context.Compilation;
         if (compilation.SyntaxTrees.FirstOrDefault()?.Options.DocumentationMode == DocumentationMode.None)
         {
@@ -70,13 +77,6 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
 
         if (!compilation.Options.Errors.IsEmpty)
         {
-            return;
-        }
-
-        DeclaredReferences? declaredReferences = GetDeclaredReferences(context);
-        if (declaredReferences == null)
-        {
-            // Reference Trimmer is disabled
             return;
         }
 

--- a/src/Tests/E2ETests.cs
+++ b/src/Tests/E2ETests.cs
@@ -290,6 +290,14 @@ public sealed class E2ETests
     }
 
     [TestMethod]
+    public Task ReferenceTrimmerDisabled()
+    {
+        return RunMSBuildAsync(
+            projectFile: "Library/Library.csproj",
+            expectedWarnings: Array.Empty<Warning>());
+    }
+
+    [TestMethod]
     public async Task LegacyStyleProject()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/Tests/TestData/ReferenceTrimmerDisabled/Library/Library.cs
+++ b/src/Tests/TestData/ReferenceTrimmerDisabled/Library/Library.cs
@@ -1,0 +1,7 @@
+﻿namespace Library
+{
+    public static class Foo
+    {
+        public static string Bar() => "Baz";
+    }
+}

--- a/src/Tests/TestData/ReferenceTrimmerDisabled/Library/Library.csproj
+++ b/src/Tests/TestData/ReferenceTrimmerDisabled/Library/Library.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <EnableReferenceTrimmer>false</EnableReferenceTrimmer>
+    <!-- Assert the analyzer does not report diagnostics if reference trimmer is disabled -->
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Move up check for declared references so warnings are not logged if reference trimmer is disabled.

Fixes #79 