### PR TITLE
Rely on file paths not assembly names

### DIFF
--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using ReferenceTrimmer.Shared;
@@ -87,7 +86,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
         {
             if (metadataReference.Display != null)
             {
-                string assemblyName = AssemblyName.GetAssemblyName(metadataReference.Display).CodeBase;
+                string assemblyName = new Uri(metadataReference.Display).LocalPath;
                 usedReferences.Add(assemblyName);
             }
         }

--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -86,8 +86,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
         {
             if (metadataReference.Display != null)
             {
-                string assemblyName = new Uri(metadataReference.Display).LocalPath;
-                usedReferences.Add(assemblyName);
+                usedReferences.Add(metadataReference.Display);
             }
         }
 
@@ -100,7 +99,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
             {
                 case DeclaredReferenceKind.Reference:
                 {
-                    if (!usedReferences.Contains(declaredReference.AssemblyName))
+                    if (!usedReferences.Contains(declaredReference.FilePath))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(RT0001Descriptor, Location.None, declaredReference.Spec));
                     }
@@ -109,7 +108,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                 }
                 case DeclaredReferenceKind.ProjectReference:
                 {
-                    if (!usedReferences.Contains(declaredReference.AssemblyName))
+                    if (!usedReferences.Contains(declaredReference.FilePath))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(RT0002Descriptor, Location.None, declaredReference.Spec));
                     }
@@ -124,7 +123,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                         packageAssembliesDict.Add(declaredReference.Spec, packageAssemblies);
                     }
 
-                    packageAssemblies.Add(declaredReference.AssemblyName);
+                    packageAssemblies.Add(declaredReference.FilePath);
                     break;
                 }
             }

--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -99,7 +99,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
             {
                 case DeclaredReferenceKind.Reference:
                 {
-                    if (!usedReferences.Contains(declaredReference.FilePath))
+                    if (!usedReferences.Contains(declaredReference.AssemblyPath))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(RT0001Descriptor, Location.None, declaredReference.Spec));
                     }
@@ -108,7 +108,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                 }
                 case DeclaredReferenceKind.ProjectReference:
                 {
-                    if (!usedReferences.Contains(declaredReference.FilePath))
+                    if (!usedReferences.Contains(declaredReference.AssemblyPath))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(RT0002Descriptor, Location.None, declaredReference.Spec));
                     }
@@ -123,7 +123,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                         packageAssembliesDict.Add(declaredReference.Spec, packageAssemblies);
                     }
 
-                    packageAssemblies.Add(declaredReference.FilePath);
+                    packageAssemblies.Add(declaredReference.AssemblyPath);
                     break;
                 }
             }

--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -87,7 +87,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
         {
             if (metadataReference.Display != null)
             {
-                string assemblyName = AssemblyName.GetAssemblyName(metadataReference.Display).Name;
+                string assemblyName = AssemblyName.GetAssemblyName(metadataReference.Display).CodeBase;
                 usedReferences.Add(assemblyName);
             }
         }

--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -18,7 +18,7 @@
       <_ReferenceTrimmerReferences Include="@(Reference)" />
       <_ReferenceTrimmerReferences Remove="@(_NETStandardLibraryNETFrameworkLib -> '%(FileName)')" />
 
-      <_ResolvedReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ResolveAssemblyReference'"/>
+      <_ReferenceTrimmerResolvedReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ResolveAssemblyReference'"/>
 
       <_ReferenceTrimmerProjectReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference'" />
     </ItemGroup>
@@ -27,7 +27,7 @@
       OutputFile="$(_ReferenceTrimmerDeclaredReferencesFile)"
       MSBuildProjectFile="$(MSBuildProjectFile)"
       References="@(_ReferenceTrimmerReferences)"
-      ResolvedReferences="@(_ResolvedReferences)"
+      ResolvedReferences="@(_ReferenceTrimmerResolvedReferences)"
       ProjectReferences="@(_ReferenceTrimmerProjectReferences)"
       PackageReferences="@(PackageReference)"
       ProjectAssetsFile="$(ProjectAssetsFile)"

--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -18,6 +18,8 @@
       <_ReferenceTrimmerReferences Include="@(Reference)" />
       <_ReferenceTrimmerReferences Remove="@(_NETStandardLibraryNETFrameworkLib -> '%(FileName)')" />
 
+      <_ResolvedReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ResolveAssemblyReference'"/>
+
       <_ReferenceTrimmerProjectReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference'" />
     </ItemGroup>
 
@@ -25,6 +27,7 @@
       OutputFile="$(_ReferenceTrimmerDeclaredReferencesFile)"
       MSBuildProjectFile="$(MSBuildProjectFile)"
       References="@(_ReferenceTrimmerReferences)"
+      ResolvedReferences="@(_ResolvedReferences)"
       ProjectReferences="@(_ReferenceTrimmerProjectReferences)"
       PackageReferences="@(PackageReference)"
       ProjectAssetsFile="$(ProjectAssetsFile)"

--- a/src/Shared/DeclaredReferences.cs
+++ b/src/Shared/DeclaredReferences.cs
@@ -27,7 +27,7 @@ internal record DeclaredReferences(IReadOnlyList<DeclaredReference> References)
 
         foreach (DeclaredReference reference in References)
         {
-            writer.Write(reference.FilePath);
+            writer.Write(reference.AssemblyPath);
             writer.Write(FieldDelimiter);
             writer.Write(KindEnumToString[reference.Kind]);
             writer.Write(FieldDelimiter);
@@ -63,6 +63,6 @@ internal record DeclaredReferences(IReadOnlyList<DeclaredReference> References)
     }
 }
 
-internal record DeclaredReference(string FilePath, DeclaredReferenceKind Kind, string Spec);
+internal record DeclaredReference(string AssemblyPath, DeclaredReferenceKind Kind, string Spec);
 
 internal enum DeclaredReferenceKind { Reference, ProjectReference, PackageReference }

--- a/src/Shared/DeclaredReferences.cs
+++ b/src/Shared/DeclaredReferences.cs
@@ -27,7 +27,7 @@ internal record DeclaredReferences(IReadOnlyList<DeclaredReference> References)
 
         foreach (DeclaredReference reference in References)
         {
-            writer.Write(reference.AssemblyName);
+            writer.Write(reference.FilePath);
             writer.Write(FieldDelimiter);
             writer.Write(KindEnumToString[reference.Kind]);
             writer.Write(FieldDelimiter);
@@ -63,6 +63,6 @@ internal record DeclaredReferences(IReadOnlyList<DeclaredReference> References)
     }
 }
 
-internal record DeclaredReference(string AssemblyName, DeclaredReferenceKind Kind, string Spec);
+internal record DeclaredReference(string FilePath, DeclaredReferenceKind Kind, string Spec);
 
 internal enum DeclaredReferenceKind { Reference, ProjectReference, PackageReference }

--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -97,17 +97,17 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
 
                     if (!string.IsNullOrEmpty(referenceHintPath) && File.Exists(referenceHintPath))
                     {
-                        referencePath = referenceHintPath;
+                        referencePath = Path.GetFullPath(referenceHintPath);
 
                         // If a hint path is given and exists, use that assembly's name.
-                        referenceAssemblyName = AssemblyName.GetAssemblyName(referenceHintPath).CodeBase;
+                        referenceAssemblyName = new Uri(referencePath).LocalPath;
                     }
                     else if (File.Exists(referenceSpec))
                     {
-                        referencePath = referenceSpec;
+                        referencePath = Path.GetFullPath(referenceSpec);
 
                         // If the spec is an existing file, use that assembly's name.
-                        referenceAssemblyName = AssemblyName.GetAssemblyName(referenceSpec).CodeBase;
+                        referenceAssemblyName = new Uri(referencePath).LocalPath;
                     }
                     else
                     {
@@ -120,7 +120,6 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                     // If the reference is under the nuget package root, it's likely a Reference added in a package's props or targets.
                     if (NuGetPackageRoot != null && referencePath != null)
                     {
-                        referencePath = Path.GetFullPath(referencePath);
                         if (referencePath.StartsWith(NuGetPackageRoot))
                         {
                             continue;
@@ -151,7 +150,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                         continue;
                     }
 
-                    string projectReferenceAssemblyName = AssemblyName.GetAssemblyName(projectReference.ItemSpec).CodeBase;
+                    string projectReferenceAssemblyName = new Uri(projectReference.ItemSpec).LocalPath;
                     string referenceProjectFile = projectReference.GetMetadata("OriginalProjectReferenceItemSpec");
 
                     declaredReferences.Add(new DeclaredReference(projectReferenceAssemblyName, DeclaredReferenceKind.ProjectReference, referenceProjectFile));
@@ -255,7 +254,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                 .Select(path =>
                 {
                     var fullPath = Path.Combine(nugetLibraryAbsolutePath, path);
-                    return AssemblyName.GetAssemblyName(fullPath).CodeBase;
+                    return new Uri(fullPath).LocalPath;
                 })
                 .ToList();
 

--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -95,26 +95,18 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                     var referenceHintPath = reference.GetMetadata("HintPath");
 
                     string? referencePath;
-                    string referenceAssemblyName;
-
                     if (!string.IsNullOrEmpty(referenceHintPath) && File.Exists(referenceHintPath))
                     {
                         referencePath = Path.GetFullPath(referenceHintPath);
-
-                        referenceAssemblyName = new Uri(referencePath).LocalPath;
                     }
                     else if (File.Exists(referenceSpec))
                     {
                         referencePath = Path.GetFullPath(referenceSpec);
-
-                        referenceAssemblyName = new Uri(referencePath).LocalPath;
                     }
                     else
                     {
                         var resolvedReference = ResolvedReferences.SingleOrDefault(rr => string.Equals(rr.GetMetadata("OriginalItemSpec"), referenceSpec, StringComparison.OrdinalIgnoreCase));
                         referencePath = resolvedReference is null ? null : resolvedReference.ItemSpec;
-
-                        referenceAssemblyName = referencePath ?? referenceSpec;
                     }
 
                     // If the reference is under the nuget package root, it's likely a Reference added in a package's props or targets.
@@ -126,7 +118,10 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                         }
                     }
 
-                    declaredReferences.Add(new DeclaredReference(referenceAssemblyName, DeclaredReferenceKind.Reference, referenceSpec));
+                    if (referencePath is not null)
+                    {
+                        declaredReferences.Add(new DeclaredReference(referencePath, DeclaredReferenceKind.Reference, referenceSpec));
+                    }
                 }
             }
 
@@ -150,7 +145,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                         continue;
                     }
 
-                    string projectReferenceAssemblyPath = new Uri(projectReference.GetMetadata("ReferenceAssembly")).LocalPath;
+                    string projectReferenceAssemblyPath = Path.GetFullPath(projectReference.GetMetadata("ReferenceAssembly"));
                     string referenceProjectFile = projectReference.GetMetadata("OriginalProjectReferenceItemSpec");
 
                     declaredReferences.Add(new DeclaredReference(projectReferenceAssemblyPath, DeclaredReferenceKind.ProjectReference, referenceProjectFile));
@@ -254,7 +249,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                 .Select(path =>
                 {
                     var fullPath = Path.Combine(nugetLibraryAbsolutePath, path);
-                    return new Uri(fullPath).LocalPath;
+                    return Path.GetFullPath(fullPath);
                 })
                 .ToList();
 

--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -150,7 +150,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                         continue;
                     }
 
-                    string projectReferenceAssemblyName = new Uri(projectReference.ItemSpec).LocalPath;
+                    string projectReferenceAssemblyName = new Uri(projectReference.GetMetadata("ReferenceAssembly")).LocalPath;
                     string referenceProjectFile = projectReference.GetMetadata("OriginalProjectReferenceItemSpec");
 
                     declaredReferences.Add(new DeclaredReference(projectReferenceAssemblyName, DeclaredReferenceKind.ProjectReference, referenceProjectFile));

--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -100,14 +100,14 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                         referencePath = referenceHintPath;
 
                         // If a hint path is given and exists, use that assembly's name.
-                        referenceAssemblyName = AssemblyName.GetAssemblyName(referenceHintPath).Name;
+                        referenceAssemblyName = AssemblyName.GetAssemblyName(referenceHintPath).CodeBase;
                     }
                     else if (File.Exists(referenceSpec))
                     {
                         referencePath = referenceSpec;
 
                         // If the spec is an existing file, use that assembly's name.
-                        referenceAssemblyName = AssemblyName.GetAssemblyName(referenceSpec).Name;
+                        referenceAssemblyName = AssemblyName.GetAssemblyName(referenceSpec).CodeBase;
                     }
                     else
                     {
@@ -151,7 +151,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                         continue;
                     }
 
-                    string projectReferenceAssemblyName = new AssemblyName(projectReference.GetMetadata("FusionName")).Name;
+                    string projectReferenceAssemblyName = AssemblyName.GetAssemblyName(projectReference.ItemSpec).CodeBase;
                     string referenceProjectFile = projectReference.GetMetadata("OriginalProjectReferenceItemSpec");
 
                     declaredReferences.Add(new DeclaredReference(projectReferenceAssemblyName, DeclaredReferenceKind.ProjectReference, referenceProjectFile));
@@ -255,7 +255,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                 .Select(path =>
                 {
                     var fullPath = Path.Combine(nugetLibraryAbsolutePath, path);
-                    return AssemblyName.GetAssemblyName(fullPath).Name;
+                    return AssemblyName.GetAssemblyName(fullPath).CodeBase;
                 })
                 .ToList();
 

--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -33,6 +33,8 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
 
     public ITaskItem[]? References { get; set; }
 
+    public ITaskItem[]? ResolvedReferences { get; set; }
+
     public ITaskItem[]? ProjectReferences { get; set; }
 
     public ITaskItem[]? PackageReferences { get; set; }
@@ -99,22 +101,20 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                     {
                         referencePath = Path.GetFullPath(referenceHintPath);
 
-                        // If a hint path is given and exists, use that assembly's name.
                         referenceAssemblyName = new Uri(referencePath).LocalPath;
                     }
                     else if (File.Exists(referenceSpec))
                     {
                         referencePath = Path.GetFullPath(referenceSpec);
 
-                        // If the spec is an existing file, use that assembly's name.
                         referenceAssemblyName = new Uri(referencePath).LocalPath;
                     }
                     else
                     {
-                        referencePath = null;
+                        var resolvedReference = ResolvedReferences.SingleOrDefault(rr => string.Equals(rr.GetMetadata("OriginalItemSpec"), referenceSpec, StringComparison.OrdinalIgnoreCase));
+                        referencePath = resolvedReference is null ? null : resolvedReference.ItemSpec;
 
-                        // The assembly name is probably just the item spec.
-                        referenceAssemblyName = referenceSpec;
+                        referenceAssemblyName = referencePath ?? referenceSpec;
                     }
 
                     // If the reference is under the nuget package root, it's likely a Reference added in a package's props or targets.

--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -120,7 +120,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                     // If the reference is under the nuget package root, it's likely a Reference added in a package's props or targets.
                     if (NuGetPackageRoot != null && referencePath != null)
                     {
-                        if (referencePath.StartsWith(NuGetPackageRoot))
+                        if (referencePath.StartsWith(NuGetPackageRoot, StringComparison.OrdinalIgnoreCase))
                         {
                             continue;
                         }
@@ -150,10 +150,10 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                         continue;
                     }
 
-                    string projectReferenceAssemblyName = new Uri(projectReference.GetMetadata("ReferenceAssembly")).LocalPath;
+                    string projectReferenceAssemblyPath = new Uri(projectReference.GetMetadata("ReferenceAssembly")).LocalPath;
                     string referenceProjectFile = projectReference.GetMetadata("OriginalProjectReferenceItemSpec");
 
-                    declaredReferences.Add(new DeclaredReference(projectReferenceAssemblyName, DeclaredReferenceKind.ProjectReference, referenceProjectFile));
+                    declaredReferences.Add(new DeclaredReference(projectReferenceAssemblyPath, DeclaredReferenceKind.ProjectReference, referenceProjectFile));
                 }
             }
 
@@ -180,9 +180,9 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                         continue;
                     }
 
-                    foreach (string assemblyName in packageInfo.CompileTimeAssemblies)
+                    foreach (string assemblyPath in packageInfo.CompileTimeAssemblies)
                     {
-                        declaredReferences.Add(new DeclaredReference(assemblyName, DeclaredReferenceKind.PackageReference, packageReference.ItemSpec));
+                        declaredReferences.Add(new DeclaredReference(assemblyPath, DeclaredReferenceKind.PackageReference, packageReference.ItemSpec));
                     }
                 }
             }

--- a/src/Tests/E2ETests.cs
+++ b/src/Tests/E2ETests.cs
@@ -38,7 +38,26 @@ public sealed class E2ETests
     }
 
     [TestMethod]
+    public Task UsedProjectReferenceReferenceProduceReferenceAssembly()
+    {
+        return RunMSBuildAsync(
+            projectFile: "Library/Library.csproj",
+            expectedWarnings: Array.Empty<Warning>());
+    }
+
+    [TestMethod]
     public Task UnusedProjectReference()
+    {
+        return RunMSBuildAsync(
+            projectFile: "Library/Library.csproj",
+            expectedWarnings: new[]
+            {
+                new Warning("RT0002: ProjectReference ../Dependency/Dependency.csproj can be removed", "Library/Library.csproj"),
+            });
+    }
+
+    [TestMethod]
+    public Task UnusedProjectReferenceProduceReferenceAssembly()
     {
         return RunMSBuildAsync(
             projectFile: "Library/Library.csproj",

--- a/src/Tests/E2ETests.cs
+++ b/src/Tests/E2ETests.cs
@@ -38,7 +38,7 @@ public sealed class E2ETests
     }
 
     [TestMethod]
-    public Task UsedProjectReferenceReferenceProduceReferenceAssembly()
+    public Task UsedProjectReferenceProduceReferenceAssembly()
     {
         return RunMSBuildAsync(
             projectFile: "Library/Library.csproj",

--- a/src/Tests/TestData/UnusedProjectReferenceProduceReferenceAssembly/Dependency/Dependency.cs
+++ b/src/Tests/TestData/UnusedProjectReferenceProduceReferenceAssembly/Dependency/Dependency.cs
@@ -1,0 +1,7 @@
+﻿namespace Dependency
+{
+    public static class Foo
+    {
+        public static string Bar() => "Baz";
+    }
+}

--- a/src/Tests/TestData/UnusedProjectReferenceProduceReferenceAssembly/Dependency/Dependency.csproj
+++ b/src/Tests/TestData/UnusedProjectReferenceProduceReferenceAssembly/Dependency/Dependency.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/TestData/UnusedProjectReferenceProduceReferenceAssembly/Library/Library.cs
+++ b/src/Tests/TestData/UnusedProjectReferenceProduceReferenceAssembly/Library/Library.cs
@@ -1,0 +1,7 @@
+﻿namespace Library
+{
+    public static class Foo
+    {
+        public static string Bar() => "Baz";
+    }
+}

--- a/src/Tests/TestData/UnusedProjectReferenceProduceReferenceAssembly/Library/Library.csproj
+++ b/src/Tests/TestData/UnusedProjectReferenceProduceReferenceAssembly/Library/Library.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/TestData/UsedProjectReferenceProduceReferenceAssembly/Dependency/Dependency.cs
+++ b/src/Tests/TestData/UsedProjectReferenceProduceReferenceAssembly/Dependency/Dependency.cs
@@ -1,0 +1,7 @@
+﻿namespace Dependency
+{
+    public static class Foo
+    {
+        public static string Bar() => "Baz";
+    }
+}

--- a/src/Tests/TestData/UsedProjectReferenceProduceReferenceAssembly/Dependency/Dependency.csproj
+++ b/src/Tests/TestData/UsedProjectReferenceProduceReferenceAssembly/Dependency/Dependency.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/TestData/UsedProjectReferenceProduceReferenceAssembly/Library/Library.cs
+++ b/src/Tests/TestData/UsedProjectReferenceProduceReferenceAssembly/Library/Library.cs
@@ -1,0 +1,7 @@
+﻿namespace Library
+{
+    public static class Foo
+    {
+        public static string Bar() => Dependency.Foo.Bar();
+    }
+}

--- a/src/Tests/TestData/UsedProjectReferenceProduceReferenceAssembly/Library/Library.csproj
+++ b/src/Tests/TestData/UsedProjectReferenceProduceReferenceAssembly/Library/Library.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "3.2",
-    "assemblyVersion": "3.2",
+    "version": "3.3",
+    "assemblyVersion": "3.3",
     "buildNumberOffset": -1,
     "publicReleaseRefSpec": [
         "^refs/tags/v\\d+\\.\\d+\\.\\d+"


### PR DESCRIPTION
Fixed #83 for improved accuracy of detection.

Added test cases for projects with `ProduceReferenceAssembly` set