### PR TITLE
Fallback to `Identity` metadata when `ReferenceAssembly` metadata is not defined on project reference

### DIFF
--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -145,10 +145,11 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                         continue;
                     }
 
-                    string projectReferenceAssemblyPath = Path.GetFullPath(projectReference.GetMetadata("ReferenceAssembly"));
+                    string referenceAssemblyPath = projectReference.GetMetadata("ReferenceAssembly");
+                    string projectAssemblyPath = Path.GetFullPath(string.IsNullOrWhiteSpace(referenceAssemblyPath) ? projectReference.GetMetadata("Identity") : referenceAssemblyPath);
                     string referenceProjectFile = projectReference.GetMetadata("OriginalProjectReferenceItemSpec");
 
-                    declaredReferences.Add(new DeclaredReference(projectReferenceAssemblyPath, DeclaredReferenceKind.ProjectReference, referenceProjectFile));
+                    declaredReferences.Add(new DeclaredReference(projectAssemblyPath, DeclaredReferenceKind.ProjectReference, referenceProjectFile));
                 }
             }
 


### PR DESCRIPTION
Fallback to `Identity` metadata when `ReferenceAssembly` metadata is not defined on project reference

On some projects (it seems to be WPF projects with project references), the `CollectDeclaredReferencesTask` fails because `projectReference.GetMetadata("ReferenceAssembly")` returns `string.Empty`.

To fix this, I fall back to the identity which appears to be the project output in this metadata.