### PR TITLE
Write used references file only if different

### DIFF
--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -90,7 +90,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        File.WriteAllLines(Path.Combine(Path.GetDirectoryName(declaredReferencesPath), UsedReferencesFileName), usedReferences);
+        WriteUsedReferencesToFile(usedReferences, declaredReferencesPath);
 
         Dictionary<string, List<string>> packageAssembliesDict = new(StringComparer.OrdinalIgnoreCase);
         foreach (DeclaredReference declaredReference in declaredReferences.References)
@@ -138,6 +138,30 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
             {
                 context.ReportDiagnostic(Diagnostic.Create(RT0003Descriptor, Location.None, packageName));
             }
+        }
+    }
+
+    private static void WriteUsedReferencesToFile(HashSet<string> usedReferences, string declaredReferencesPath)
+    {
+        string filePath = Path.Combine(Path.GetDirectoryName(declaredReferencesPath), UsedReferencesFileName);
+
+        string text = string.Join(Environment.NewLine, usedReferences.OrderBy(s => s));
+
+        try
+        {
+            if (File.Exists(filePath))
+            {
+                string oldText = File.ReadAllText(filePath);
+                if (string.Equals(text, oldText, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+            }
+
+            File.WriteAllText(filePath, text);
+        }
+        catch
+        {
         }
     }
 


### PR DESCRIPTION
Since the analyzer runs on every keystroke in the IDE it's important to reduce I/O and first-chance exceptions

Sample exception:
```
System.IO.IOException: The process cannot access the file 'C:\ReferenceTrimmer\src\Analyzer\obj\Debug\netstandard2.0\_ReferenceTrimmer_UsedReferences.log' because it is being used by another process.
   at void System.IO.File.WriteAllText(string path, string contents)
   at void ReferenceTrimmer.Analyzer.ReferenceTrimmerAnalyzer.WriteUsedReferencesToFile(HashSet<string> usedReferences, string declaredReferencesPath) in C:/ReferenceTrimmer/src/Analyzer/ReferenceTrimmerAnalyzer.cs:line 161
   at void Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteCompilationActions(ImmutableArray<CompilationAnalyzerAction> compilationActions, DiagnosticAnalyzer analyzer, CompilationEvent compilationEvent, CancellationToken cancellationToken)+((Action<CompilationAnalysisContext> action, CompilationAnalysisContext context) data) => { } in C:/Roslyn/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs:line 332
```