### PR TITLE
Use ReferencePathWithRefAssemblies.Identity instead of ReferencePath.ReferenceAssembly

### DIFF
--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -18,9 +18,9 @@
       <_ReferenceTrimmerReferences Include="@(Reference)" />
       <_ReferenceTrimmerReferences Remove="@(_NETStandardLibraryNETFrameworkLib -> '%(FileName)')" />
 
-      <_ReferenceTrimmerResolvedReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ResolveAssemblyReference'"/>
+      <_ReferenceTrimmerResolvedReferences Include="@(ReferencePathWithRefAssemblies)" Condition="'%(ReferencePathWithRefAssemblies.ReferenceSourceTarget)' == 'ResolveAssemblyReference'"/>
 
-      <_ReferenceTrimmerProjectReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference'" />
+      <_ReferenceTrimmerProjectReferences Include="@(ReferencePathWithRefAssemblies)" Condition="'%(ReferencePathWithRefAssemblies.ReferenceSourceTarget)' == 'ProjectReference'" />
     </ItemGroup>
 
     <CollectDeclaredReferencesTask

--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -145,7 +145,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                         continue;
                     }
 
-                    string projectReferenceAssemblyPath = Path.GetFullPath(projectReference.GetMetadata("ReferenceAssembly"));
+                    string projectReferenceAssemblyPath = Path.GetFullPath(projectReference.ItemSpec);
                     string referenceProjectFile = projectReference.GetMetadata("OriginalProjectReferenceItemSpec");
 
                     declaredReferences.Add(new DeclaredReference(projectReferenceAssemblyPath, DeclaredReferenceKind.ProjectReference, referenceProjectFile));

--- a/src/Tests/E2ETests.cs
+++ b/src/Tests/E2ETests.cs
@@ -46,6 +46,14 @@ public sealed class E2ETests
     }
 
     [TestMethod]
+    public Task UsedProjectReferenceNoReferenceAssembly()
+    {
+        return RunMSBuildAsync(
+            projectFile: "Library/Library.csproj",
+            expectedWarnings: Array.Empty<Warning>());
+    }
+
+    [TestMethod]
     public Task UnusedProjectReference()
     {
         return RunMSBuildAsync(
@@ -58,6 +66,17 @@ public sealed class E2ETests
 
     [TestMethod]
     public Task UnusedProjectReferenceProduceReferenceAssembly()
+    {
+        return RunMSBuildAsync(
+            projectFile: "Library/Library.csproj",
+            expectedWarnings: new[]
+            {
+                new Warning("RT0002: ProjectReference ../Dependency/Dependency.csproj can be removed", "Library/Library.csproj"),
+            });
+    }
+
+    [TestMethod]
+    public Task UnusedProjectReferenceNoReferenceAssembly()
     {
         return RunMSBuildAsync(
             projectFile: "Library/Library.csproj",

--- a/src/Tests/E2ETests.cs
+++ b/src/Tests/E2ETests.cs
@@ -448,6 +448,14 @@ public sealed class E2ETests
             expectUnusedMsvcLibrariesLog: true);
     }
 
+    [TestMethod]
+    public Task WpfApp()
+    {
+        return RunMSBuildAsync(
+            projectFile: "WpfApp/WpfApp.csproj",
+            expectedWarnings: Array.Empty<Warning>());
+    }
+
     private static (string ExePath, string Verb) GetMsBuildExeAndVerb()
     {
         // On Windows, try to find Visual Studio

--- a/src/Tests/TestData/UnusedProjectReferenceNoReferenceAssembly/Dependency/Dependency.cs
+++ b/src/Tests/TestData/UnusedProjectReferenceNoReferenceAssembly/Dependency/Dependency.cs
@@ -1,0 +1,7 @@
+﻿namespace Dependency
+{
+    public static class Foo
+    {
+        public static string Bar() => "Baz";
+    }
+}

--- a/src/Tests/TestData/UnusedProjectReferenceNoReferenceAssembly/Dependency/Dependency.csproj
+++ b/src/Tests/TestData/UnusedProjectReferenceNoReferenceAssembly/Dependency/Dependency.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/TestData/UnusedProjectReferenceNoReferenceAssembly/Library/Library.cs
+++ b/src/Tests/TestData/UnusedProjectReferenceNoReferenceAssembly/Library/Library.cs
@@ -1,0 +1,7 @@
+﻿namespace Library
+{
+    public static class Foo
+    {
+        public static string Bar() => "Baz";
+    }
+}

--- a/src/Tests/TestData/UnusedProjectReferenceNoReferenceAssembly/Library/Library.csproj
+++ b/src/Tests/TestData/UnusedProjectReferenceNoReferenceAssembly/Library/Library.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/TestData/UsedProjectReferenceNoReferenceAssembly/Dependency/Dependency.cs
+++ b/src/Tests/TestData/UsedProjectReferenceNoReferenceAssembly/Dependency/Dependency.cs
@@ -1,0 +1,7 @@
+﻿namespace Dependency
+{
+    public static class Foo
+    {
+        public static string Bar() => "Baz";
+    }
+}

--- a/src/Tests/TestData/UsedProjectReferenceNoReferenceAssembly/Dependency/Dependency.csproj
+++ b/src/Tests/TestData/UsedProjectReferenceNoReferenceAssembly/Dependency/Dependency.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/TestData/UsedProjectReferenceNoReferenceAssembly/Library/Library.cs
+++ b/src/Tests/TestData/UsedProjectReferenceNoReferenceAssembly/Library/Library.cs
@@ -1,0 +1,7 @@
+﻿namespace Library
+{
+    public static class Foo
+    {
+        public static string Bar() => Dependency.Foo.Bar();
+    }
+}

--- a/src/Tests/TestData/UsedProjectReferenceNoReferenceAssembly/Library/Library.csproj
+++ b/src/Tests/TestData/UsedProjectReferenceNoReferenceAssembly/Library/Library.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/TestData/WpfApp/Dependency/Dependency.cs
+++ b/src/Tests/TestData/WpfApp/Dependency/Dependency.cs
@@ -1,0 +1,7 @@
+﻿namespace Dependency
+{
+    public static class Foo
+    {
+        public static string Bar() => "Baz";
+    }
+}

--- a/src/Tests/TestData/WpfApp/Dependency/Dependency.csproj
+++ b/src/Tests/TestData/WpfApp/Dependency/Dependency.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/TestData/WpfApp/WpfApp/App.xaml
+++ b/src/Tests/TestData/WpfApp/WpfApp/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="WpfApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:WpfApp"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/src/Tests/TestData/WpfApp/WpfApp/App.xaml.cs
+++ b/src/Tests/TestData/WpfApp/WpfApp/App.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace WpfApp
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+        // Use the dependency
+        public string X = Dependency.Foo.Bar();
+    }
+}

--- a/src/Tests/TestData/WpfApp/WpfApp/AssemblyInfo.cs
+++ b/src/Tests/TestData/WpfApp/WpfApp/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/src/Tests/TestData/WpfApp/WpfApp/MainWindow.xaml
+++ b/src/Tests/TestData/WpfApp/WpfApp/MainWindow.xaml
@@ -1,0 +1,12 @@
+﻿<Window x:Class="WpfApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:WpfApp"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+
+    </Grid>
+</Window>

--- a/src/Tests/TestData/WpfApp/WpfApp/MainWindow.xaml.cs
+++ b/src/Tests/TestData/WpfApp/WpfApp/MainWindow.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace WpfApp
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Tests/TestData/WpfApp/WpfApp/WpfApp.csproj
+++ b/src/Tests/TestData/WpfApp/WpfApp/WpfApp.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Use ReferencePathWithRefAssemblies.Identity instead of ReferencePath.ReferenceAssembly

Related to #88.

Today we're using `ReferencePath.ReferenceAssembly`, which in practice is usually the correct value, but `ReferencePathWithRefAssemblies` is what is actually passed to the compiler in the end.

In most cases, the `FindReferenceAssembliesForReferences` target ends up populating `ReferencePath.ReferenceAssembly` if needed, and then populating `ReferencePathWithRefAssemblies` with `ReferencePath.ReferenceAssembly`:
```xml
  <Target Name="FindReferenceAssembliesForReferences"
          DependsOnTargets="ResolveReferences">
    <ItemGroup>
      <!-- Reference assemblies are not produced in all cases, but it's easier to consume them
           if this metadatum is always populated. Ensure that it points to the implementation
           assembly unless already specified. -->
      <ReferencePath Condition="'%(ReferencePath.ReferenceAssembly)' == ''">
        <ReferenceAssembly>%(FullPath)</ReferenceAssembly>
      </ReferencePath>

      <ReferencePathWithRefAssemblies Include="@(ReferencePath->'%(ReferenceAssembly)')"
                                      Condition="'$(CompileUsingReferenceAssemblies)' != 'false'">
        <OriginalPath Condition="'%(ReferencePath.Identity)' != '@(ReferencePath->'%(ReferenceAssembly)')'">%(ReferencePath.Identity)</OriginalPath>
      </ReferencePathWithRefAssemblies>
      <ReferencePathWithRefAssemblies Include="@(ReferencePath)"
                                      Condition="'$(CompileUsingReferenceAssemblies)' == 'false'" />
    </ItemGroup>
  </Target>
```

However, there also exists a `ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies` target with a comment which adds some nuance.

```xml
  <Target Name="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies"
          BeforeTargets="CoreCompile"
          Condition="'@(ReferencePathWithRefAssemblies)' == ''">
    <!-- 
      FindReferenceAssembliesForReferences target in Common targets populate this item 
      since dev15.3. The compiler targets may be used (via NuGet package) on earlier MSBuilds. 
      If the ReferencePathWithRefAssemblies item is not populated, just use ReferencePaths 
      (implementation assemblies) as they are.
      
      Since XAML inner build runs CoreCompile directly (instead of Compile target),
      it also doesn't invoke FindReferenceAssembliesForReferences listed in CompileDependsOn.
      In that case we also populate ReferencePathWithRefAssemblies with implementation assemblies.
    -->
    <ItemGroup>
      <ReferencePathWithRefAssemblies Include="@(ReferencePath)" />
    </ItemGroup>
  </Target>
```

According to the comment, the generated XAML projects do not call `FindReferenceAssembliesForReferences` and thus `ReferencePath.ReferenceAssembly` won't be set. The `ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies` shims up the `ReferencePathWithRefAssemblies` item though, which is why we should be using that instead of `ReferencePath.ReferenceAssembly`