### PR TITLE
Write unused references to a log file

### DIFF
--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -10,6 +10,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
 {
     private const string DeclaredReferencesFileName = "_ReferenceTrimmer_DeclaredReferences.tsv";
     private const string UsedReferencesFileName = "_ReferenceTrimmer_UsedReferences.log";
+    private const string UnusedReferencesFileName = "_ReferenceTrimmer_UnusedReferences.log";
 
     private static readonly DiagnosticDescriptor RT0000Descriptor = new(
         "RT0000",

--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -5,10 +5,15 @@
   <PropertyGroup>
     <CoreCompileDependsOn Condition="'$(EnableReferenceTrimmer)' != 'false'">$(CoreCompileDependsOn);CollectDeclaredReferences</CoreCompileDependsOn>
   </PropertyGroup>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="EnableReferenceTrimmerDiagnostics"/>
+  </ItemGroup>
 
   <Target Name="CollectDeclaredReferences" DependsOnTargets="ResolveAssemblyReferences;PrepareProjectReferences">
     <PropertyGroup>
       <_ReferenceTrimmerDeclaredReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_DeclaredReferences.tsv</_ReferenceTrimmerDeclaredReferencesFile>
+      <_ReferenceTrimmerUsedReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_UsedReferences.log</_ReferenceTrimmerUsedReferencesFile>
+      <_ReferenceTrimmerUnusedReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_UnusedReferences.log</_ReferenceTrimmerUnusedReferencesFile>
     </PropertyGroup>
     <ItemGroup>
       <!--
@@ -42,6 +47,8 @@
       <!-- https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Using%20Additional%20Files.md#in-a-project-file -->
       <AdditionalFiles Include="$(_ReferenceTrimmerDeclaredReferencesFile)" />
       <FileWrites Include="$(_ReferenceTrimmerDeclaredReferencesFile)" />
+      <FileWrites Include="$(_ReferenceTrimmerUsedReferencesFile)" Condition="'$(EnableReferenceTrimmerDiagnostics)'=='true'" />
+      <FileWrites Include="$(_ReferenceTrimmerUnusedReferencesFile)" Condition="'$(EnableReferenceTrimmerDiagnostics)'=='true'" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Tests/E2ETests.cs
+++ b/src/Tests/E2ETests.cs
@@ -626,7 +626,11 @@ Actual warnings:
             }
         }
 
-        Assert.AreEqual(enableReferenceTrimmerDiagnostics, File.Exists(Path.Combine(testDataSourcePath, "Library", "obj", "Debug", "net472", "_ReferenceTrimmer_UsedReferences.log")));
-        Assert.AreEqual(enableReferenceTrimmerDiagnostics, File.Exists(Path.Combine(testDataSourcePath, "Library", "obj", "Debug", "net472", "_ReferenceTrimmer_UnusedReferences.log")));
+        string intermediateLibraryPath = Path.Combine(testDataSourcePath, "Library", "obj");
+        // local tests run debug, CI builds run release, thus the assertion needs to look for the file
+        var usedReferencesFiles = Directory.GetFiles(intermediateLibraryPath, "_ReferenceTrimmer_UsedReferences.log", SearchOption.AllDirectories);
+        var unusedReferencesFiles = Directory.GetFiles(intermediateLibraryPath, "_ReferenceTrimmer_UnusedReferences.log", SearchOption.AllDirectories);
+        Assert.AreEqual(enableReferenceTrimmerDiagnostics, usedReferencesFiles.Length == 1);
+        Assert.AreEqual(enableReferenceTrimmerDiagnostics, unusedReferencesFiles.Length == 1);
     }
 }

--- a/src/Tests/E2ETests.cs
+++ b/src/Tests/E2ETests.cs
@@ -626,11 +626,10 @@ Actual warnings:
             }
         }
 
-        string intermediateLibraryPath = Path.Combine(testDataSourcePath, "Library", "obj");
         // local tests run debug, CI builds run release, thus the assertion needs to look for the file
-        var usedReferencesFiles = Directory.GetFiles(intermediateLibraryPath, "_ReferenceTrimmer_UsedReferences.log", SearchOption.AllDirectories);
-        var unusedReferencesFiles = Directory.GetFiles(intermediateLibraryPath, "_ReferenceTrimmer_UnusedReferences.log", SearchOption.AllDirectories);
-        Assert.AreEqual(enableReferenceTrimmerDiagnostics, usedReferencesFiles.Length == 1);
-        Assert.AreEqual(enableReferenceTrimmerDiagnostics, unusedReferencesFiles.Length == 1);
+        var usedReferencesFiles = Directory.GetFiles(testDataSourcePath, "_ReferenceTrimmer_UsedReferences.log", SearchOption.AllDirectories);
+        var unusedReferencesFiles = Directory.GetFiles(testDataSourcePath, "_ReferenceTrimmer_UnusedReferences.log", SearchOption.AllDirectories);
+        Assert.AreEqual(enableReferenceTrimmerDiagnostics, usedReferencesFiles.Length > 0);
+        Assert.AreEqual(enableReferenceTrimmerDiagnostics, unusedReferencesFiles.Length > 0);
     }
 }


### PR DESCRIPTION
Roslyn analyzer has all the inputs to write all (unfiltered) unused references. This can be handy for debugging.