### PR TITLE
Defer evaluation of EnableReferenceTrimmer

### DIFF
--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -3,13 +3,13 @@
   <UsingTask TaskName="CollectDeclaredReferencesTask" AssemblyFile="$(ReferenceTrimmerTasksAssembly)" />
 
   <PropertyGroup>
-    <CoreCompileDependsOn Condition="'$(EnableReferenceTrimmer)' != 'false'">$(CoreCompileDependsOn);CollectDeclaredReferences</CoreCompileDependsOn>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);CollectDeclaredReferences</CoreCompileDependsOn>
   </PropertyGroup>
   <ItemGroup>
     <CompilerVisibleProperty Include="EnableReferenceTrimmerDiagnostics"/>
   </ItemGroup>
 
-  <Target Name="CollectDeclaredReferences" DependsOnTargets="ResolveAssemblyReferences;PrepareProjectReferences">
+  <Target Name="CollectDeclaredReferences" DependsOnTargets="$(CollectDeclaredReferencesDependsOn);ResolveAssemblyReferences;PrepareProjectReferences" Condition="'$(EnableReferenceTrimmer)' != 'false'">
     <PropertyGroup>
       <_ReferenceTrimmerDeclaredReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_DeclaredReferences.tsv</_ReferenceTrimmerDeclaredReferencesFile>
       <_ReferenceTrimmerUsedReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_UsedReferences.log</_ReferenceTrimmerUsedReferencesFile>

--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -10,13 +10,13 @@
     <CompilerVisibleProperty Include="EnableReferenceTrimmerDiagnostics"/>
   </ItemGroup>
 
-  <Target Name="CollectDeclaredReferences" DependsOnTargets="$(CollectDeclaredReferencesDependsOn)" Condition="'$(EnableReferenceTrimmer)' != 'false'">
-    <PropertyGroup>
+  <Target Name="CollectDeclaredReferences" DependsOnTargets="$(CollectDeclaredReferencesDependsOn)">
+    <PropertyGroup Condition="'$(EnableReferenceTrimmer)' != 'false'">
       <_ReferenceTrimmerDeclaredReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_DeclaredReferences.tsv</_ReferenceTrimmerDeclaredReferencesFile>
       <_ReferenceTrimmerUsedReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_UsedReferences.log</_ReferenceTrimmerUsedReferencesFile>
       <_ReferenceTrimmerUnusedReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_UnusedReferences.log</_ReferenceTrimmerUnusedReferencesFile>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition="'$(EnableReferenceTrimmer)' != 'false'">
       <!--
         Microsoft.NET.Build.Extensions may add many references to help bridge the gap with older
         versions of .NET Framework and .NET Standard. Avoid reporting these as unused.
@@ -30,6 +30,7 @@
     </ItemGroup>
 
     <CollectDeclaredReferencesTask
+      Condition="'$(EnableReferenceTrimmer)' != 'false'"
       OutputFile="$(_ReferenceTrimmerDeclaredReferencesFile)"
       MSBuildProjectFile="$(MSBuildProjectFile)"
       References="@(_ReferenceTrimmerReferences)"
@@ -44,7 +45,7 @@
       TargetFrameworkDirectories="$(TargetFrameworkDirectory)"
       NuGetPackageRoot="$(NuGetPackageRoot)" />
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(EnableReferenceTrimmer)' != 'false'">
       <!-- https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Using%20Additional%20Files.md#in-a-project-file -->
       <AdditionalFiles Include="$(_ReferenceTrimmerDeclaredReferencesFile)" />
       <FileWrites Include="$(_ReferenceTrimmerDeclaredReferencesFile)" />

--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -4,12 +4,13 @@
 
   <PropertyGroup>
     <CoreCompileDependsOn>$(CoreCompileDependsOn);CollectDeclaredReferences</CoreCompileDependsOn>
+    <CollectDeclaredReferencesDependsOn>$(CollectDeclaredReferencesDependsOn);ResolveAssemblyReferences;PrepareProjectReferences</CollectDeclaredReferencesDependsOn>
   </PropertyGroup>
   <ItemGroup>
     <CompilerVisibleProperty Include="EnableReferenceTrimmerDiagnostics"/>
   </ItemGroup>
 
-  <Target Name="CollectDeclaredReferences" DependsOnTargets="$(CollectDeclaredReferencesDependsOn);ResolveAssemblyReferences;PrepareProjectReferences" Condition="'$(EnableReferenceTrimmer)' != 'false'">
+  <Target Name="CollectDeclaredReferences" DependsOnTargets="$(CollectDeclaredReferencesDependsOn)" Condition="'$(EnableReferenceTrimmer)' != 'false'">
     <PropertyGroup>
       <_ReferenceTrimmerDeclaredReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_DeclaredReferences.tsv</_ReferenceTrimmerDeclaredReferencesFile>
       <_ReferenceTrimmerUsedReferencesFile>$(IntermediateOutputPath)\_ReferenceTrimmer_UsedReferences.log</_ReferenceTrimmerUsedReferencesFile>

--- a/src/Tests/E2ETests.cs
+++ b/src/Tests/E2ETests.cs
@@ -283,6 +283,17 @@ public sealed class E2ETests
     }
 
     [TestMethod]
+    public Task UnusedPackageReferenceDeferred()
+    {
+        return RunMSBuildAsync(
+            projectFile: "Library/Library.csproj",
+            expectedWarnings: new[]
+            {
+                new Warning("RT0003: PackageReference Newtonsoft.Json can be removed", "Library/Library.csproj")
+            });
+    }
+
+    [TestMethod]
     public Task UnusedPackageReferenceNoWarn()
     {
         return RunMSBuildAsync(

--- a/src/Tests/TestData/UnusedPackageReferenceDeferred/Library/Library.csproj
+++ b/src/Tests/TestData/UnusedPackageReferenceDeferred/Library/Library.csproj
@@ -4,14 +4,13 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net472</TargetFramework>
     <EnableReferenceTrimmer>false</EnableReferenceTrimmer>
-    <CollectDeclaredReferencesDependsOn>$(CollectDeclaredReferencesDependsOn);SetEnableReferenceTrimmer</CollectDeclaredReferencesDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
-  <Target Name="SetEnableReferenceTrimmer">
+  <Target Name="SetEnableReferenceTrimmer" BeforeTargets="CollectDeclaredReferences">
     <ItemGroup>
       <DependencyExists Include="true" Condition="'%(PackageReference.Identity)' == 'Newtonsoft.Json'"/>
     </ItemGroup>

--- a/src/Tests/TestData/UnusedPackageReferenceDeferred/Library/Library.csproj
+++ b/src/Tests/TestData/UnusedPackageReferenceDeferred/Library/Library.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <EnableReferenceTrimmer>false</EnableReferenceTrimmer>
+    <CollectDeclaredReferencesDependsOn>$(CollectDeclaredReferencesDependsOn);SetEnableReferenceTrimmer</CollectDeclaredReferencesDependsOn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+  </ItemGroup>
+
+  <Target Name="SetEnableReferenceTrimmer">
+    <ItemGroup>
+      <DependencyExists Include="true" Condition="'%(PackageReference.Identity)' == 'Newtonsoft.Json'"/>
+    </ItemGroup>
+    <PropertyGroup Condition="'@(DependencyExists)' != ''">
+      <EnableReferenceTrimmer>true</EnableReferenceTrimmer>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "3.3",
-    "assemblyVersion": "3.3",
+    "version": "3.4",
+    "assemblyVersion": "3.4",
     "buildNumberOffset": -1,
     "publicReleaseRefSpec": [
         "^refs/tags/v\\d+\\.\\d+\\.\\d+"


### PR DESCRIPTION
Fixes #96 

Evaluation of the condition just before the task execution allows to have the property modified in a custom task (also plugged in through a new depends-on property).