### PR TITLE
Fix loading UsingTask first before property is populated.

### DIFF
--- a/src/Package/build/ReferenceTrimmer.props
+++ b/src/Package/build/ReferenceTrimmer.props
@@ -1,9 +1,5 @@
 <Project>
 
-  <PropertyGroup>
-    <ReferenceTrimmerTasksAssembly Condition=" '$(ReferenceTrimmerTasksAssembly)' == '' ">$(MSBuildThisFileDirectory)ReferenceTrimmer.Tasks.dll</ReferenceTrimmerTasksAssembly>
-  </PropertyGroup>
-
   <ItemDefinitionGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' and '$(ReferenceTrimmerEnableVcxproj)' != 'false' ">
     <Link>
         <!-- Enable link.exe traceouts of unused libraries and delay-load DLLs from vcxproj projects.

--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <UsingTask TaskName="CollectDeclaredReferencesTask" AssemblyFile="$(ReferenceTrimmerTasksAssembly)" />
+  <UsingTask TaskName="CollectDeclaredReferencesTask" AssemblyFile="$(ReferenceTrimmerTasksAssembly)" Condition=" '$(ReferenceTrimmerTasksAssembly)' != '' " />
+  <UsingTask TaskName="CollectDeclaredReferencesTask" AssemblyFile="$(MSBuildThisFileDirectory)ReferenceTrimmer.Tasks.dll" Condition=" '$(ReferenceTrimmerTasksAssembly)' == '' " />
 
   <PropertyGroup>
     <CoreCompileDependsOn Condition="'$(EnableReferenceTrimmer)' != 'false'">$(CoreCompileDependsOn);CollectDeclaredReferences</CoreCompileDependsOn>


### PR DESCRIPTION
referencetrimmer\3.3.11\build\ReferenceTrimmer.targets line 3 pos 55: MSB4022 The result "" of evaluating the value "$(ReferenceTrimmerTasksAssembly)" of the "AssemblyFile" attribute in element <UsingTask> is not valid.