### PR TITLE
Add System.ValueTuple to IgnorePackageBuildFiles

### DIFF
--- a/src/Package/build/ReferenceTrimmer.props
+++ b/src/Package/build/ReferenceTrimmer.props
@@ -59,6 +59,7 @@
     <ReferenceTrimmerIgnorePackageBuildFiles Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <ReferenceTrimmerIgnorePackageBuildFiles Include="Microsoft.Extensions.Primitives" />
     <ReferenceTrimmerIgnorePackageBuildFiles Include="System.Text.Json" />
+    <ReferenceTrimmerIgnorePackageBuildFiles Include="System.ValueTuple" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
System.ValueTuple's `buildTransitive` targets are not consequential but were causing packages that transitively depend on it (e.g. AutoMapper) to be skipped. Adding it to the default `ReferenceTrimmerIgnorePackageBuildFiles` list prevents this.

Fixes #133