### PR TITLE
Make CollectDeclaredReferences target incremental

### DIFF
--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -9,7 +9,11 @@
     <CompilerVisibleProperty Include="EnableReferenceTrimmerDiagnostics"/>
   </ItemGroup>
 
-  <Target Name="CollectDeclaredReferences" DependsOnTargets="ResolveAssemblyReferences;PrepareProjectReferences" Condition="'$(EnableReferenceTrimmer)' != 'false'">
+  <Target Name="CollectDeclaredReferences"
+          DependsOnTargets="ResolveAssemblyReferences;PrepareProjectReferences"
+          Condition="'$(EnableReferenceTrimmer)' != 'false'"
+          Inputs="$(MSBuildProjectFullPath);$(ProjectAssetsFile)"
+          Outputs="$(MSBuildProjectDirectory)\$(IntermediateOutputPath)_ReferenceTrimmer_DeclaredReferences.tsv">
     <PropertyGroup>
       <_ReferenceTrimmerDeclaredReferencesFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)_ReferenceTrimmer_DeclaredReferences.tsv'))</_ReferenceTrimmerDeclaredReferencesFile>
       <_ReferenceTrimmerUsedReferencesFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)_ReferenceTrimmer_UsedReferences.log'))</_ReferenceTrimmerUsedReferencesFile>

--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -506,6 +506,9 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
             string existing = File.ReadAllText(filePath);
             if (string.Equals(existing, newContent, StringComparison.OrdinalIgnoreCase))
             {
+                // Touch the file so that MSBuild's Inputs/Outputs incrementality check
+                // sees a fresh timestamp and can skip the target on subsequent builds.
+                File.SetLastWriteTimeUtc(filePath, DateTime.UtcNow);
                 return;
             }
         }


### PR DESCRIPTION
Add Inputs/Outputs to the CollectDeclaredReferences target so MSBuild can skip it on incremental builds when project file and assets file haven't changed.

Two changes were needed:

1. Target Inputs/Outputs: Use \ for the Outputs path instead of GetFullPath(), since GetFullPath() resolves relative to the process working directory rather than the project directory.

2. Touch output file on unchanged content: SaveDeclaredReferences() has a write-only-if-different optimization that prevents updating the file timestamp when content is identical. This causes MSBuild to always consider the target out of date. Now we touch the file timestamp even when content is unchanged.

Tested on a 305-project build (NeMo/Hardware in Azure-Compute-Move):
- Before: CollectDeclaredReferences 26.8s (305 executions, 0 skipped)
- After:  CollectDeclaredReferences 0s (305 skipped)