### PR TITLE
Remove redundant Microsoft.SourceLink.GitHub package reference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,14 +48,11 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
-  <!-- Source Link (https://github.com/dotnet/sourcelink) -->
+  <!-- Source Link -->
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
 
   <!-- Versioning (https://github.com/dotnet/Nerdbank.GitVersioning) -->
   <ItemGroup>


### PR DESCRIPTION
The .NET 8+ SDK includes SourceLink support natively, making the explicit `Microsoft.SourceLink.GitHub` package reference unnecessary.

### Changes
- Removed the `Microsoft.SourceLink.GitHub` PackageReference and its surrounding `ItemGroup` from `Directory.Build.props`
- Retained the SourceLink MSBuild properties (`PublishRepositoryUrl`, `EmbedUntrackedSources`) as they are still needed