### PR TITLE
Cover type forwarding and other gaps

### DIFF
--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -446,6 +446,28 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                     return;
                 }
 
+                // Mark type-forwarding assemblies as used when the destination assembly is used.
+                // E.g. a package may forward types to the runtime; the code uses the type (tracking the
+                // runtime assembly) but the forwarder assembly must also be kept as a reference.
+                foreach (KeyValuePair<string, IAssemblySymbol> kvp in pathToAssembly)
+                {
+                    if (usedReferencePaths.ContainsKey(kvp.Key))
+                    {
+                        continue;
+                    }
+
+                    foreach (INamedTypeSymbol forwardedType in kvp.Value.GetForwardedTypes())
+                    {
+                        if (forwardedType.ContainingAssembly != null
+                            && assemblyToPath.TryGetValue(forwardedType.ContainingAssembly.Identity, out string? destPath)
+                            && usedReferencePaths.ContainsKey(destPath))
+                        {
+                            usedReferencePaths.TryAdd(kvp.Key, 0);
+                            break;
+                        }
+                    }
+                }
+
                 HashSet<string> usedReferences = new(usedReferencePaths.Keys, StringComparer.OrdinalIgnoreCase);
 
                 // For bare Reference items (RT0001), we always need a conservative "transitively used" set

--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -1,10 +1,12 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
 using ReferenceTrimmer.Shared;
+using CSharp = Microsoft.CodeAnalysis.CSharp;
 
 namespace ReferenceTrimmer.Analyzer;
 
@@ -70,7 +72,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
         context.RegisterCompilationStartAction(CompilationStart);
     }
 
@@ -214,6 +216,14 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                     case IPointerTypeSymbol pointer:
                         type = pointer.PointedAtType;
                         continue;
+                    case IFunctionPointerTypeSymbol funcPtr:
+                        TrackType(funcPtr.Signature.ReturnType);
+                        foreach (IParameterSymbol fpParam in funcPtr.Signature.Parameters)
+                        {
+                            TrackType(fpParam.Type);
+                        }
+
+                        return;
                     default:
                         TrackAssembly(type.ContainingAssembly);
                         if (type is INamedTypeSymbol named)
@@ -416,6 +426,35 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                     case ICatchClauseOperation catchClause:
                         TrackType(catchClause.ExceptionType);
                         break;
+
+                    case ISwitchExpressionArmOperation switchArm:
+                        TrackPatternTypes(switchArm.Pattern);
+                        break;
+
+                    case IPatternCaseClauseOperation patternClause:
+                        TrackPatternTypes(patternClause.Pattern);
+                        break;
+
+                    case ILocalFunctionOperation localFunc:
+                        TrackType(localFunc.Symbol.ReturnType);
+                        foreach (IParameterSymbol lfParam in localFunc.Symbol.Parameters)
+                        {
+                            TrackType(lfParam.Type);
+                        }
+
+                        break;
+
+                    case IAnonymousFunctionOperation lambda:
+                        foreach (IParameterSymbol lambdaParam in lambda.Symbol.Parameters)
+                        {
+                            TrackType(lambdaParam.Type);
+                        }
+
+                        break;
+
+                    case ISizeOfOperation sizeOfOp:
+                        TrackType(sizeOfOp.TypeOperand);
+                        break;
                 }
             },
             OperationKind.Invocation,
@@ -428,7 +467,20 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
             OperationKind.Conversion,
             OperationKind.IsType,
             OperationKind.IsPattern,
-            OperationKind.CatchClause);
+            OperationKind.CatchClause,
+            OperationKind.SwitchExpressionArm,
+            OperationKind.CaseClause,
+            OperationKind.LocalFunction,
+            OperationKind.AnonymousFunction,
+            OperationKind.SizeOf);
+
+        // Track nameof() and XML doc cref references via language-specific syntax actions.
+        // These require syntax-level analysis because nameof is lowered to a string literal
+        // and crefs live in documentation trivia — neither surfaces through IOperation.
+        if (compilation.Language == LanguageNames.CSharp)
+        {
+            RegisterCSharpSyntaxTracking(context, TrackAssembly, TrackType);
+        }
 
         context.RegisterCompilationEndAction(endContext =>
         {
@@ -575,6 +627,72 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                 context.ReportDiagnostic(Diagnostic.Create(RT0003Descriptor, Location.None, packageName));
             }
         }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Language-specific syntax tracking (nameof, crefs)
+    // ──────────────────────────────────────────────────────────────────────
+
+    // Separate methods per language to avoid JIT-loading the wrong language assembly.
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RegisterCSharpSyntaxTracking(
+        CompilationStartAnalysisContext context,
+        Action<IAssemblySymbol?> trackAssembly,
+        Action<ITypeSymbol?> trackType)
+    {
+        // nameof() — appears as InvocationExpression at the syntax level but is
+        // lowered to a string literal in the IOperation tree.
+        context.RegisterSyntaxNodeAction(ctx =>
+        {
+            if (ctx.Node is CSharp.Syntax.InvocationExpressionSyntax invocation
+                && invocation.Expression is CSharp.Syntax.IdentifierNameSyntax id
+                && id.Identifier.Text == "nameof"
+                && invocation.ArgumentList.Arguments.Count > 0)
+            {
+                // Verify it is actually the nameof operator, not a method called "nameof".
+                SymbolInfo invocationInfo = ctx.SemanticModel.GetSymbolInfo(invocation, ctx.CancellationToken);
+                if (invocationInfo.Symbol is IMethodSymbol)
+                {
+                    return;
+                }
+
+                SymbolInfo argInfo = ctx.SemanticModel.GetSymbolInfo(invocation.ArgumentList.Arguments[0].Expression, ctx.CancellationToken);
+                ISymbol? symbol = argInfo.Symbol ?? argInfo.CandidateSymbols.FirstOrDefault();
+                if (symbol is ITypeSymbol typeSymbol)
+                {
+                    trackType(typeSymbol);
+                }
+                else if (symbol != null)
+                {
+                    trackAssembly(symbol.ContainingAssembly);
+                }
+            }
+        }, CSharp.SyntaxKind.InvocationExpression);
+
+        // XML doc <cref> — only relevant when documentation generation is enabled,
+        // matching the behavior of GetUsedAssemblyReferences() in the legacy path.
+        context.RegisterSyntaxNodeAction(ctx =>
+        {
+            if (ctx.SemanticModel.SyntaxTree.Options.DocumentationMode == DocumentationMode.None)
+            {
+                return;
+            }
+
+            if (ctx.Node is CSharp.Syntax.XmlCrefAttributeSyntax cref)
+            {
+                SymbolInfo symbolInfo = ctx.SemanticModel.GetSymbolInfo(cref.Cref, ctx.CancellationToken);
+                ISymbol? symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+                if (symbol is ITypeSymbol typeSymbol)
+                {
+                    trackType(typeSymbol);
+                }
+                else if (symbol != null)
+                {
+                    trackAssembly(symbol.ContainingAssembly);
+                }
+            }
+        }, CSharp.SyntaxKind.XmlCrefAttribute);
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/src/Tests/E2ETests.cs
+++ b/src/Tests/E2ETests.cs
@@ -65,6 +65,42 @@ public sealed class E2ETests
     }
 
     [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public Task UsedProjectReferenceSwitchPattern(bool useSymbolAnalysis)
+    {
+        // Dependency type used only in switch expression type pattern and switch case clause pattern.
+        return RunMSBuildAsync(
+            projectFile: "Library/Library.csproj",
+            expectedWarnings: [],
+            useSymbolAnalysis: useSymbolAnalysis);
+    }
+
+    [TestMethod]
+    public Task UsedProjectReferenceNameof()
+    {
+        // Dependency type used only in nameof(). nameof is lowered to a string literal
+        // in IOperation, so only the syntax-level handler catches it. Symbol-analysis only.
+        return RunMSBuildAsync(
+            projectFile: "Library/Library.csproj",
+            expectedWarnings: [],
+            useSymbolAnalysis: true);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public Task UsedProjectReferenceCref(bool useSymbolAnalysis)
+    {
+        // Dependency type used only in XML doc <see cref="..."/>.
+        // Both legacy (GetUsedAssemblyReferences with doc mode on) and symbol-based paths handle this.
+        return RunMSBuildAsync(
+            projectFile: "Library/Library.csproj",
+            expectedWarnings: [],
+            useSymbolAnalysis: useSymbolAnalysis);
+    }
+
+    [TestMethod]
     [DataRow(true, false)]
     [DataRow(false, false)]
     [DataRow(true, true)]

--- a/src/Tests/TestData/UsedProjectReferenceCref/Dependency/Dependency.cs
+++ b/src/Tests/TestData/UsedProjectReferenceCref/Dependency/Dependency.cs
@@ -1,0 +1,7 @@
+namespace Dependency
+{
+    public static class Foo
+    {
+        public static string Bar() => "Baz";
+    }
+}

--- a/src/Tests/TestData/UsedProjectReferenceCref/Dependency/Dependency.csproj
+++ b/src/Tests/TestData/UsedProjectReferenceCref/Dependency/Dependency.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/TestData/UsedProjectReferenceCref/Library/Library.cs
+++ b/src/Tests/TestData/UsedProjectReferenceCref/Library/Library.cs
@@ -1,0 +1,13 @@
+namespace Library
+{
+    public static class Bar
+    {
+        /// <summary>
+        /// See <see cref="Dependency.Foo"/> for details.
+        /// </summary>
+        /// <remarks>
+        /// Also references <see cref="Dependency.Foo.Bar"/>.
+        /// </remarks>
+        public static string GetName() => "bar";
+    }
+}

--- a/src/Tests/TestData/UsedProjectReferenceCref/Library/Library.csproj
+++ b/src/Tests/TestData/UsedProjectReferenceCref/Library/Library.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/TestData/UsedProjectReferenceNameof/Dependency/Dependency.cs
+++ b/src/Tests/TestData/UsedProjectReferenceNameof/Dependency/Dependency.cs
@@ -1,0 +1,7 @@
+namespace Dependency
+{
+    public static class Foo
+    {
+        public static string Bar() => "Baz";
+    }
+}

--- a/src/Tests/TestData/UsedProjectReferenceNameof/Dependency/Dependency.csproj
+++ b/src/Tests/TestData/UsedProjectReferenceNameof/Dependency/Dependency.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/TestData/UsedProjectReferenceNameof/Library/Library.cs
+++ b/src/Tests/TestData/UsedProjectReferenceNameof/Library/Library.cs
@@ -1,0 +1,9 @@
+namespace Library
+{
+    public static class Bar
+    {
+        // Dependency.Foo used only in nameof() — lowered to a string literal in the IOperation tree.
+        // Only the syntax-level nameof handler catches this.
+        public static string GetName() => nameof(Dependency.Foo);
+    }
+}

--- a/src/Tests/TestData/UsedProjectReferenceNameof/Library/Library.csproj
+++ b/src/Tests/TestData/UsedProjectReferenceNameof/Library/Library.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/TestData/UsedProjectReferenceSwitchPattern/Dependency/Dependency.cs
+++ b/src/Tests/TestData/UsedProjectReferenceSwitchPattern/Dependency/Dependency.cs
@@ -1,0 +1,6 @@
+namespace Dependency
+{
+    public class Foo
+    {
+    }
+}

--- a/src/Tests/TestData/UsedProjectReferenceSwitchPattern/Dependency/Dependency.csproj
+++ b/src/Tests/TestData/UsedProjectReferenceSwitchPattern/Dependency/Dependency.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tests/TestData/UsedProjectReferenceSwitchPattern/Library/Library.cs
+++ b/src/Tests/TestData/UsedProjectReferenceSwitchPattern/Library/Library.cs
@@ -1,0 +1,22 @@
+namespace Library
+{
+    public static class Bar
+    {
+        // Dependency.Foo used only in switch expression type pattern (ISwitchExpressionArmOperation)
+        public static string CategorizeExpr(object obj) => obj switch
+        {
+            Dependency.Foo => "foo",
+            _ => "other"
+        };
+
+        // Dependency.Foo used only in switch case clause pattern (IPatternCaseClauseOperation)
+        public static string CategorizeStmt(object obj)
+        {
+            switch (obj)
+            {
+                case Dependency.Foo _: return "foo";
+                default: return "other";
+            }
+        }
+    }
+}

--- a/src/Tests/TestData/UsedProjectReferenceSwitchPattern/Library/Library.csproj
+++ b/src/Tests/TestData/UsedProjectReferenceSwitchPattern/Library/Library.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Dependency/Dependency.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This pull request enhances the ReferenceTrimmer analyzer to more accurately detect used project references in C# code, especially in cases that previously required syntax-level analysis. The changes add support for tracking references used only in `nameof()` expressions, XML documentation `<cref>` attributes, and advanced pattern-matching constructs. Comprehensive tests are included to verify these scenarios.

**Analyzer improvements:**

* Added syntax-level tracking for `nameof()` expressions and XML doc `<cref>` references, ensuring references used only in these contexts are not incorrectly reported as unused. This is implemented via a new `RegisterCSharpSyntaxTracking` method and corresponding registration in the analyzer. [[1]](diffhunk://#diff-4e304ebead097220cddf37675021352ba27c9fa61c3d0d6e91f1949d24d07d53R3-R9) [[2]](diffhunk://#diff-4e304ebead097220cddf37675021352ba27c9fa61c3d0d6e91f1949d24d07d53L431-R483) [[3]](diffhunk://#diff-4e304ebead097220cddf37675021352ba27c9fa61c3d0d6e91f1949d24d07d53R632-R697)
* Expanded pattern-matching support to track types used in switch expression arms, pattern case clauses, local functions, anonymous functions, and `sizeof` operations, improving accuracy for modern C# code. [[1]](diffhunk://#diff-4e304ebead097220cddf37675021352ba27c9fa61c3d0d6e91f1949d24d07d53R429-R457) [[2]](diffhunk://#diff-4e304ebead097220cddf37675021352ba27c9fa61c3d0d6e91f1949d24d07d53L431-R483)
* Improved handling of type-forwarded assemblies to ensure that assemblies forwarding types to used assemblies are also marked as used.
* Changed generated code analysis configuration to analyze (not skip) generated code, increasing coverage.
* Added handling for function pointer types in type tracking logic.

**Test coverage:**

* Added end-to-end tests for scenarios where project references are used only via `nameof()`, XML doc `<cref>`, and advanced switch patterns, with corresponding test projects and source files. [[1]](diffhunk://#diff-2ba13d8141b7420f1c67784458e92f8f1de03f32e42f224b32e2e8cd1bb2f753R67-R102) [[2]](diffhunk://#diff-50ec53adb6576807df48ce86f6029755c9134d4213d41e85b5b5c93a102d6d64R1-R7) [[3]](diffhunk://#diff-b72ec48b78d2161df68ce29ac58bd2807896d9792f9817b948ce85ee27ba4f72R1-R8) [[4]](diffhunk://#diff-1ed4f705781a63a789a5c647923345776708565ce81fda25d9856518d25d4096R1-R13) [[5]](diffhunk://#diff-d060dbfc079ade6fb1b28c1343cd3ae7a09544c21ca6bbb1a601b71e3818cacdR1-R12) [[6]](diffhunk://#diff-35f77593397c35362dd362347f2bdd6b9762499d357fc44ab9be596222cbc25fR1-R9) [[7]](diffhunk://#diff-9753eee4a43cd0fca32eb14f86daa42bfe0d4ecf05068a844aded4df3d3c14dbR1-R6) [[8]](diffhunk://#diff-daebd7695452bac45015b59530d74b5b27069d9231f6bd5c97fac214d92ce44fR1-R22) [[9]](diffhunk://#diff-731b4c345e6bf9bad0f58c4cab2950267a6f88f3a3bcd1ae0b96ebd3a533105dR1-R13)

These improvements ensure that the analyzer correctly identifies all used references, even in subtle or modern C# usage patterns.