### PR TITLE
Fix NRE in CollectDeclaredReferencesTask when ResolvedReferences is null

### DIFF
--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -109,8 +109,8 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                     }
                     else
                     {
-                        var resolvedReference = ResolvedReferences.SingleOrDefault(rr => string.Equals(rr.GetMetadata("OriginalItemSpec"), referenceSpec, StringComparison.OrdinalIgnoreCase));
-                        referencePath = resolvedReference is null ? null : resolvedReference.ItemSpec;
+                        var resolvedReference = ResolvedReferences?.SingleOrDefault(rr => string.Equals(rr.GetMetadata("OriginalItemSpec"), referenceSpec, StringComparison.OrdinalIgnoreCase));
+                        referencePath = resolvedReference?.ItemSpec;
                     }
 
                     // If the reference is under the nuget package root, it's likely a Reference added in a package's props or targets.
@@ -225,7 +225,18 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
         var packageInfoBuilders = new Dictionary<string, PackageInfoBuilder>(StringComparer.OrdinalIgnoreCase);
 
         Log.LogMessage(MessageImportance.Low, "Loading lock file from '{0}'", ProjectAssetsFile);
-        var lockFile = LockFileUtilities.GetLockFile(ProjectAssetsFile, NullLogger.Instance);
+        var lockFile = string.IsNullOrEmpty(ProjectAssetsFile)
+            ? null
+            : LockFileUtilities.GetLockFile(ProjectAssetsFile, NullLogger.Instance);
+        if (lockFile is null)
+        {
+            // ProjectAssetsFile may be null/missing for projects that don't use NuGet restore (e.g., legacy or non-SDK projects
+            // that nevertheless have items in @(PackageReference)). Without a lock file we can't resolve package contents, so
+            // skip package processing rather than NRE on the null lockFile below.
+            Log.LogMessage(MessageImportance.Low, "Lock file '{0}' is null or could not be loaded; skipping PackageReference processing", ProjectAssetsFile);
+            return new Dictionary<string, PackageInfo>(StringComparer.OrdinalIgnoreCase);
+        }
+
         var packageFolders = lockFile.PackageFolders.Select(item => item.Path).ToList();
         Log.LogMessage(MessageImportance.Low, "Package folders: {0}", string.Join("; ", packageFolders));
 

--- a/src/Tests/CollectDeclaredReferencesTaskTests.cs
+++ b/src/Tests/CollectDeclaredReferencesTaskTests.cs
@@ -1,0 +1,161 @@
+using System.Collections;
+using Microsoft.Build.Framework;
+using ReferenceTrimmer.Tasks;
+
+namespace ReferenceTrimmer.Tests;
+
+[TestClass]
+public sealed class CollectDeclaredReferencesTaskTests
+{
+    [TestMethod]
+    public void ExecuteWithAllNullCollectionInputsDoesNotThrow()
+    {
+        string outputFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".tsv");
+        try
+        {
+            var engine = new MockBuildEngine();
+            var task = new CollectDeclaredReferencesTask
+            {
+                BuildEngine = engine,
+                OutputFile = outputFile,
+                References = null,
+                ResolvedReferences = null,
+                ProjectReferences = null,
+                PackageReferences = null,
+                IgnorePackageBuildFiles = null,
+                TargetFrameworkDirectories = null,
+            };
+
+            bool result = task.Execute();
+
+            Assert.IsTrue(result, "Task should succeed when all collection inputs are null. Errors: " + string.Join("; ", engine.Errors));
+            Assert.AreEqual(0, engine.Errors.Count, "No errors should be logged. Errors: " + string.Join("; ", engine.Errors));
+        }
+        finally
+        {
+            if (File.Exists(outputFile))
+            {
+                File.Delete(outputFile);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void ExecuteWithNullResolvedReferencesAndUnresolvableReferenceDoesNotThrow()
+    {
+        // Repros the vcxproj NRE: a Reference whose path can't be found locally falls into the
+        // ResolvedReferences.SingleOrDefault branch, but ResolvedReferences is null because
+        // ReferencePathWithRefAssemblies is empty/uninitialized for vcxproj projects.
+        string outputFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".tsv");
+        try
+        {
+            var engine = new MockBuildEngine();
+            var task = new CollectDeclaredReferencesTask
+            {
+                BuildEngine = engine,
+                OutputFile = outputFile,
+                References = new ITaskItem[]
+                {
+                    new MockTaskItem("SomeUnresolvableReference"),
+                },
+                ResolvedReferences = null,
+            };
+
+            bool result = task.Execute();
+
+            Assert.IsTrue(result, "Task should succeed even when ResolvedReferences is null. Errors: " + string.Join("; ", engine.Errors));
+            Assert.AreEqual(0, engine.Errors.Count, "No errors should be logged. Errors: " + string.Join("; ", engine.Errors));
+        }
+        finally
+        {
+            if (File.Exists(outputFile))
+            {
+                File.Delete(outputFile);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void ExecuteWithPackageReferencesAndNullProjectAssetsFileDoesNotThrow()
+    {
+        // Guards against NRE inside GetPackageInfos when PackageReferences is non-null but
+        // ProjectAssetsFile is null/missing (no NuGet restore performed for this project).
+        string outputFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".tsv");
+        try
+        {
+            var engine = new MockBuildEngine();
+            var task = new CollectDeclaredReferencesTask
+            {
+                BuildEngine = engine,
+                OutputFile = outputFile,
+                PackageReferences = new ITaskItem[]
+                {
+                    new MockTaskItem("SomePackage"),
+                },
+                ProjectAssetsFile = null,
+            };
+
+            bool result = task.Execute();
+
+            Assert.IsTrue(result, "Task should succeed when ProjectAssetsFile is null. Errors: " + string.Join("; ", engine.Errors));
+            Assert.AreEqual(0, engine.Errors.Count, "No errors should be logged. Errors: " + string.Join("; ", engine.Errors));
+        }
+        finally
+        {
+            if (File.Exists(outputFile))
+            {
+                File.Delete(outputFile);
+            }
+        }
+    }
+
+    private sealed class MockBuildEngine : IBuildEngine
+    {
+        public List<string> Errors { get; } = new();
+        public List<string> Warnings { get; } = new();
+        public List<string> Messages { get; } = new();
+
+        public bool ContinueOnError => false;
+        public int LineNumberOfTaskNode => 0;
+        public int ColumnNumberOfTaskNode => 0;
+        public string ProjectFileOfTaskNode => string.Empty;
+
+        public void LogErrorEvent(BuildErrorEventArgs e) => Errors.Add(e.Message ?? string.Empty);
+        public void LogWarningEvent(BuildWarningEventArgs e) => Warnings.Add(e.Message ?? string.Empty);
+        public void LogMessageEvent(BuildMessageEventArgs e) => Messages.Add(e.Message ?? string.Empty);
+        public void LogCustomEvent(CustomBuildEventArgs e) { }
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs) => false;
+    }
+
+    private sealed class MockTaskItem : ITaskItem
+    {
+        private readonly Dictionary<string, string> _metadata = new(StringComparer.OrdinalIgnoreCase);
+
+        public MockTaskItem(string itemSpec)
+        {
+            ItemSpec = itemSpec;
+        }
+
+        public string ItemSpec { get; set; }
+
+        public ICollection MetadataNames => _metadata.Keys;
+
+        public int MetadataCount => _metadata.Count;
+
+        public IDictionary CloneCustomMetadata() => new Dictionary<string, string>(_metadata);
+
+        public void CopyMetadataTo(ITaskItem destinationItem)
+        {
+            foreach (var kvp in _metadata)
+            {
+                destinationItem.SetMetadata(kvp.Key, kvp.Value);
+            }
+        }
+
+        public string GetMetadata(string metadataName) => _metadata.TryGetValue(metadataName, out var value) ? value : string.Empty;
+
+        public void RemoveMetadata(string metadataName) => _metadata.Remove(metadataName);
+
+        public void SetMetadata(string metadataName, string metadataValue) => _metadata[metadataName] = metadataValue;
+    }
+}

--- a/src/Tests/ReferenceTrimmer.Tests.csproj
+++ b/src/Tests/ReferenceTrimmer.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Analyzer\ReferenceTrimmer.Analyzer.csproj" />
+    <ProjectReference Include="..\Tasks\ReferenceTrimmer.Tasks.csproj" />
     <ProjectReference Include="..\Package\ReferenceTrimmer.Package.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Targets>Build;Pack</Targets>


### PR DESCRIPTION
Fixes an `ArgumentNullException` from `CollectDeclaredReferencesTask.Execute()` observed on Substrate vcxproj builds with ReferenceTrimmer 3.3.12+:

```
error MSB4018: The "CollectDeclaredReferencesTask" task failed unexpectedly.
System.ArgumentNullException: Value cannot be null. Parameter name: source
   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at ReferenceTrimmer.Tasks.CollectDeclaredReferencesTask.Execute()
```

## Root cause

`ResolvedReferences` is declared `ITaskItem[]?` but was dereferenced unconditionally on the `referenceHintPath` / `referenceSpec` fallback path. On vcxproj projects, `_ReferenceTrimmerResolvedReferences` (sourced from `ReferencePathWithRefAssemblies`) is empty/uninitialized and MSBuild passes `null` to the task instead of an empty array → NRE.

## Changes

- **`CollectDeclaredReferencesTask.cs`**:
  - Guard `ResolvedReferences?.SingleOrDefault(...)` with the null-conditional operator.
  - Audit fix in `GetPackageInfos()`: short-circuit when `ProjectAssetsFile` is null/missing and when `LockFileUtilities.GetLockFile` returns null (legacy or non-SDK projects can have `PackageReferences` without a project.assets.json).
- **New unit tests** (`CollectDeclaredReferencesTaskTests.cs`) drive the task directly with null inputs:
  - All collection inputs null.
  - The vcxproj repro: a `Reference` whose path can't be resolved locally with `ResolvedReferences = null`.
  - `PackageReferences` non-null with `ProjectAssetsFile = null`.
- `Tests` project now references `Tasks` so the task can be unit-tested; small `MockBuildEngine` / `MockTaskItem` helpers added.

All other nullable collection inputs in `Execute()` (`References`, `ProjectReferences`, `PackageReferences`, `IgnorePackageBuildFiles`, `TargetFrameworkDirectories`) are already null-checked.