### PR TITLE
Track type qualifier in member access for inherited static members

### DIFF
--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -752,6 +752,25 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
             }
         }, CSharp.SyntaxKind.InvocationExpression);
 
+        // Type qualifier in member access (e.g., `Foo.StaticMethod()` or `Foo.NestedType`).
+        // For static method calls and static member references, the receiver type appears at
+        // the syntax level as a qualifier — it isn't represented in IOperation (Instance is
+        // null for static, and the operation tree only carries TargetMethod/Member which point
+        // to the *defining* assembly, not the qualifier's assembly). Without this, calls like
+        // `Derived.InheritedStaticMethod()` would only credit the base class's assembly and
+        // the derived class's assembly would be wrongly flagged as removable.
+        context.RegisterSyntaxNodeAction(ctx =>
+        {
+            if (ctx.Node is CSharp.Syntax.MemberAccessExpressionSyntax memberAccess)
+            {
+                SymbolInfo info = ctx.SemanticModel.GetSymbolInfo(memberAccess.Expression, ctx.CancellationToken);
+                if ((info.Symbol ?? info.CandidateSymbols.FirstOrDefault()) is ITypeSymbol typeSymbol)
+                {
+                    trackType(typeSymbol);
+                }
+            }
+        }, CSharp.SyntaxKind.SimpleMemberAccessExpression);
+
         // XML doc <cref> — only relevant when documentation generation is enabled,
         // matching the behavior of GetUsedAssemblyReferences() in the legacy path.
         context.RegisterSyntaxNodeAction(ctx =>

--- a/src/Tests/AnalyzerTests.cs
+++ b/src/Tests/AnalyzerTests.cs
@@ -488,6 +488,45 @@ public sealed class AnalyzerTests
         Assert.AreEqual("RT0001", diagnostics[0].Id);
     }
 
+    [TestMethod]
+    public async Task UsedViaInheritedStaticMethod()
+    {
+        // The static method is *defined* on the base class in another assembly, but called
+        // through the derived class. Without tracking the type qualifier in the member access
+        // syntax, only the base assembly would be credited and the derived assembly would be
+        // wrongly flagged as unused.
+        var baseAsm = EmitDependency(
+            "namespace Dep { public class Base { public static void Foo() {} } }",
+            assemblyName: "BaseAsm");
+        var derivedAsm = EmitDependency(
+            "namespace Dep { public class Derived : Base { } }",
+            assemblyName: "DerivedAsm",
+            additionalReferences: [baseAsm.Reference]);
+        var diagnostics = await RunAnalyzerAsync(
+            "class C { void M() { Dep.Derived.Foo(); } }",
+            [(baseAsm.Reference, baseAsm.Path, "ProjectReference", "../Base/Base.csproj"),
+             (derivedAsm.Reference, derivedAsm.Path, "ProjectReference", "../Derived/Derived.csproj")]);
+        AssertNoDiagnostics(diagnostics);
+    }
+
+    [TestMethod]
+    public async Task UsedViaInheritedStaticField()
+    {
+        // Static field defined on base, accessed via the derived type.
+        var baseAsm = EmitDependency(
+            "namespace Dep { public class Base { public static int Counter; } }",
+            assemblyName: "BaseAsm");
+        var derivedAsm = EmitDependency(
+            "namespace Dep { public class Derived : Base { } }",
+            assemblyName: "DerivedAsm",
+            additionalReferences: [baseAsm.Reference]);
+        var diagnostics = await RunAnalyzerAsync(
+            "class C { int M() => Dep.Derived.Counter; }",
+            [(baseAsm.Reference, baseAsm.Path, "ProjectReference", "../Base/Base.csproj"),
+             (derivedAsm.Reference, derivedAsm.Path, "ProjectReference", "../Derived/Derived.csproj")]);
+        AssertNoDiagnostics(diagnostics);
+    }
+
     // ──────────────────────────────────────────────────────────────────────
     //  Test infrastructure
     // ──────────────────────────────────────────────────────────────────────
@@ -507,12 +546,24 @@ public sealed class AnalyzerTests
     /// Compile dependency source into a DLL on disk and return the metadata reference + path.
     /// </summary>
     private static (MetadataReference Reference, string Path) EmitDependency(string source, string assemblyName = "Dependency")
+        => EmitDependency(source, assemblyName, additionalReferences: null);
+
+    private static (MetadataReference Reference, string Path) EmitDependency(
+        string source,
+        string assemblyName,
+        MetadataReference[]? additionalReferences)
     {
         var tree = CSharpSyntaxTree.ParseText(source);
+        var references = new List<MetadataReference> { CorlibRef };
+        if (additionalReferences != null)
+        {
+            references.AddRange(additionalReferences);
+        }
+
         var compilation = CSharpCompilation.Create(
             assemblyName,
             [tree],
-            [CorlibRef],
+            references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
         string path = Path.Combine(Path.GetTempPath(), $"RT_Test_{assemblyName}_{Guid.NewGuid():N}.dll");


### PR DESCRIPTION
## Problem

In the symbol-based analysis path (`ReferenceTrimmerUseSymbolAnalysis=true`, opt-in via PR #135), inherited static members aren't credited to the derived class's assembly. For code like:

```csharp
Dep.Derived.InheritedStaticMethod();
```

…where `InheritedStaticMethod` is defined on a base class in a different assembly than `Derived`, the analyzer would track only the base assembly. The derived assembly's `ProjectReference` was wrongly flagged as removable (RT0002), even though removing it would leave the call unresolved.

## Why the original logic missed it

For static invocations and static member references:
- `IInvocationOperation.Instance` / `IMemberReferenceOperation.Instance` are `null` (no instance receiver).
- `invocation.TargetMethod.ContainingAssembly` / `memberRef.Member.ContainingAssembly` resolve to the *defining* assembly, which can be a base class in another assembly.
- The qualifier (`Derived`) only appears at the syntax level — there's no `IOperation` node carrying its type.

## Fix

Register a syntax action on `SimpleMemberAccessExpression` that resolves the qualifier expression via `SemanticModel.GetSymbolInfo` and, when the qualifier resolves to an `ITypeSymbol`, tracks it via the existing `TrackType` path.

## Tests

Two regression tests added, both verified to fail without the fix:
- `UsedViaInheritedStaticMethod` — `Dep.Derived.Foo()` where `Foo` is inherited from `Dep.Base` in a different assembly.
- `UsedViaInheritedStaticField` — same pattern for a static field.

Also added an `EmitDependency` overload that accepts additional metadata references so the test infra can build a derived assembly that references a base assembly.

All 38 analyzer tests pass (was 36).

## Scope

C# only. The default `GetUsedAssemblyReferences` path is unaffected. The opt-in symbol-analysis path is still experimental.