### PR TITLE
Track delegate parameter and return types in symbol-based mode

### DIFF
--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -333,6 +333,25 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                             TrackAttribute(attr);
                         }
 
+                        // For delegates, the parameter and return types live on the implicitly-declared
+                        // Invoke method, which the SymbolKind.Method action does not fire for. Walk them here.
+                        // Mirrors the IMethodSymbol case below (return type, parameter types, return-type
+                        // attributes); type-parameter constraints are already covered above for the delegate
+                        // type itself, and parameter attributes are not tracked for ordinary methods either.
+                        if (namedType.TypeKind == TypeKind.Delegate && namedType.DelegateInvokeMethod is IMethodSymbol invoke)
+                        {
+                            TrackType(invoke.ReturnType);
+                            foreach (IParameterSymbol param in invoke.Parameters)
+                            {
+                                TrackType(param.Type);
+                            }
+
+                            foreach (AttributeData attr in invoke.GetReturnTypeAttributes())
+                            {
+                                TrackAttribute(attr);
+                            }
+                        }
+
                         break;
 
                     case IMethodSymbol method:

--- a/src/Tests/AnalyzerTests.cs
+++ b/src/Tests/AnalyzerTests.cs
@@ -489,6 +489,66 @@ public sealed class AnalyzerTests
     }
 
     [TestMethod]
+    public async Task UsedViaDelegateParameterType()
+    {
+        // The external type is referenced only via a delegate's parameter type.
+        // The delegate's Invoke method is implicitly declared, so a SymbolKind.Method
+        // action does not fire for it — the analyzer must track parameters/return type
+        // through the INamedTypeSymbol with TypeKind.Delegate.
+        var dep = EmitDependency("namespace Dep { public class Service {} }");
+        var diagnostics = await RunAnalyzerAsync(
+            "public delegate void Configure(Dep.Service s);",
+            dep);
+        AssertNoDiagnostics(diagnostics);
+    }
+
+    [TestMethod]
+    public async Task UsedViaDelegateReturnType()
+    {
+        // The external type is referenced only via a delegate's return type.
+        var dep = EmitDependency("namespace Dep { public class Result {} }");
+        var diagnostics = await RunAnalyzerAsync(
+            "public delegate Dep.Result Produce();",
+            dep);
+        AssertNoDiagnostics(diagnostics);
+    }
+
+    [TestMethod]
+    public async Task UsedViaDelegateGenericReturnType()
+    {
+        // The external type is referenced only via a generic argument in the delegate's return type.
+        var dep = EmitDependency("namespace Dep { public class Item {} }");
+        var diagnostics = await RunAnalyzerAsync(
+            "public delegate System.Collections.Generic.List<Dep.Item> ProduceItems();",
+            dep);
+        AssertNoDiagnostics(diagnostics);
+    }
+
+    [TestMethod]
+    public async Task UsedViaDelegateTypeParameterConstraint()
+    {
+        // External type referenced only via a type parameter constraint on a generic delegate.
+        var dep = EmitDependency("namespace Dep { public class Base {} }");
+        var diagnostics = await RunAnalyzerAsync(
+            "public delegate void Apply<T>(T x) where T : Dep.Base;",
+            dep);
+        AssertNoDiagnostics(diagnostics);
+    }
+
+    [TestMethod]
+    public async Task UnusedDelegateNoExternalTypesReportsDiagnostic()
+    {
+        // Negative test: a delegate using only same-assembly types should NOT mark
+        // an unrelated external assembly as used.
+        var dep = EmitDependency("namespace Dep { public class Service {} }");
+        var diagnostics = await RunAnalyzerAsync(
+            "public class Local {} public delegate Local Produce(Local x);",
+            dep);
+        Assert.AreEqual(1, diagnostics.Length);
+        Assert.AreEqual("RT0002", diagnostics[0].Id);
+    }
+
+    [TestMethod]
     public async Task UsedViaInheritedStaticMethod()
     {
         // The static method is *defined* on the base class in another assembly, but called


### PR DESCRIPTION
The symbol-based usage analyzer (`ReferenceTrimmerUseSymbolAnalysis=true`) missed delegate parameter and return types because the implicitly-declared `DelegateInvokeMethod` does not fire the `SymbolKind.Method` action. With a declaration like:

```csharp
public delegate void Configure(IServiceCollection services);
```

if `IServiceCollection`'s containing assembly was referenced only through this delegate, RT0002 would falsely flag the reference as removable.

### Fix

When the symbol action sees an `INamedTypeSymbol` with `TypeKind.Delegate`, walk `DelegateInvokeMethod`'s return type, parameter types, and return-type attributes — mirroring the existing `IMethodSymbol` branch. (Type-parameter constraints are already covered by the surrounding `INamedTypeSymbol` case.)

### Tests

Adds five regression tests:
- Delegate with external parameter type (the reported repro)
- Delegate with external return type
- Delegate with external generic-argument return type (e.g. `List<External>`)
- Generic delegate with external type-parameter constraint
- Negative: delegate using only same-assembly types does not mark unrelated external assemblies as used