### PR TITLE
Emit informational messages when NoWarn and Diagnostics enabled

### DIFF
--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -934,7 +934,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
 
         if (context.Options.AnalyzerConfigOptionsProvider.GlobalOptions
                 .TryGetValue("build_property.EnableReferenceTrimmerDiagnostics", out string? enableDiagnostics)
-            && string.Equals(enableDiagnostics, "true", StringComparison.OrdinalIgnoreCase))
+            && bool.TrueString.Equals(enableDiagnostics, StringComparison.OrdinalIgnoreCase))
         {
             HashSet<string> unusedReferences = new(PathComparer);
             foreach (MetadataReference metadataReference in compilation.References)
@@ -949,6 +949,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
         }
 
         Dictionary<string, List<string>> packageAssembliesDict = new(PathComparer);
+        Dictionary<string, DiagnosticSeverity> packageSeverities = new(PathComparer);
         foreach (DeclaredReference declaredReference in ReadDeclaredReferences(sourceText))
         {
             switch (declaredReference.Kind)
@@ -958,7 +959,8 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                     // Use the conservative transitively-used set for bare References
                     if (!transitivelyUsedReferences.Contains(declaredReference.AssemblyPath))
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(RT0001Descriptor, Location.None, declaredReference.Spec));
+                        DiagnosticSeverity severity = ToDiagnosticSeverity(declaredReference.Severity);
+                        context.ReportDiagnostic(Diagnostic.Create(RT0001Descriptor, Location.None, effectiveSeverity: severity, additionalLocations: null, properties: null, declaredReference.Spec));
                     }
 
                     break;
@@ -967,7 +969,8 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                 {
                     if (!projectReferenceUsedSet.Contains(declaredReference.AssemblyPath))
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(RT0002Descriptor, Location.None, declaredReference.Spec));
+                        DiagnosticSeverity severity = ToDiagnosticSeverity(declaredReference.Severity);
+                        context.ReportDiagnostic(Diagnostic.Create(RT0002Descriptor, Location.None, effectiveSeverity: severity, additionalLocations: null, properties: null, declaredReference.Spec));
                     }
 
                     break;
@@ -981,6 +984,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                     }
 
                     packageAssemblies.Add(declaredReference.AssemblyPath);
+                    packageSeverities.Add(declaredReference.Spec, ToDiagnosticSeverity(declaredReference.Severity));
                     break;
                 }
             }
@@ -993,7 +997,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
             List<string> packageAssemblies = kvp.Value;
             if (!usedReferences.Overlaps(packageAssemblies))
             {
-                context.ReportDiagnostic(Diagnostic.Create(RT0003Descriptor, Location.None, packageName));
+                context.ReportDiagnostic(Diagnostic.Create(RT0003Descriptor, Location.None, effectiveSeverity: packageSeverities[kvp.Key], additionalLocations: null, properties: null, packageName));
             }
         }
     }
@@ -1160,7 +1164,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // File format: tab-separated fields (AssemblyPath, Kind, Spec), one reference per line.
+    // File format: tab-separated fields (AssemblyPath, Kind, Spec, Severity), one reference per line.
     // Keep in sync with SaveDeclaredReferences in CollectDeclaredReferencesTask.cs.
     private static IEnumerable<DeclaredReference> ReadDeclaredReferences(SourceText sourceText)
     {
@@ -1178,6 +1182,7 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
 
             int firstTab = -1;
             int secondTab = -1;
+            int thirdTab = -1;
             for (int i = start; i < end; i++)
             {
                 if (sourceText[i] == '\t')
@@ -1186,21 +1191,25 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                     {
                         firstTab = i;
                     }
-                    else
+                    else if (secondTab == -1)
                     {
                         secondTab = i;
-                        break;
+                    }
+                    else
+                    {
+                        thirdTab = i;
                     }
                 }
             }
 
-            if (firstTab == -1 || secondTab == -1)
+            if (firstTab == -1 || secondTab == -1 || thirdTab == -1)
             {
                 yield break;
             }
 
             string assemblyPath = sourceText.ToString(TextSpan.FromBounds(start, firstTab));
-            string spec = sourceText.ToString(TextSpan.FromBounds(secondTab + 1, end));
+            string spec = sourceText.ToString(TextSpan.FromBounds(secondTab + 1, thirdTab));
+            Enum.TryParse<ReferenceTrimmerSeverity>(sourceText.ToString(TextSpan.FromBounds(thirdTab + 1, end)), out var severity);
 
             // Determine kind without allocating a string. The three possible values are
             // "Reference" (len 9), "ProjectReference" (len 16), "PackageReference" (len 16).
@@ -1223,7 +1232,15 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            yield return new DeclaredReference(assemblyPath, kind, spec);
+            yield return new DeclaredReference(assemblyPath, kind, spec, severity);
         }
     }
+
+    private static DiagnosticSeverity ToDiagnosticSeverity(ReferenceTrimmerSeverity severity) => severity switch
+    {
+        ReferenceTrimmerSeverity.Hidden => DiagnosticSeverity.Hidden,
+        ReferenceTrimmerSeverity.Info => DiagnosticSeverity.Info,
+        ReferenceTrimmerSeverity.Warning => DiagnosticSeverity.Warning,
+        _ => throw new ArgumentOutOfRangeException(nameof(severity), $"Unexpected severity value: {severity}")
+    };
 }

--- a/src/Analyzer/ReferenceTrimmerAnalyzer.cs
+++ b/src/Analyzer/ReferenceTrimmerAnalyzer.cs
@@ -984,7 +984,10 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
                     }
 
                     packageAssemblies.Add(declaredReference.AssemblyPath);
-                    packageSeverities.Add(declaredReference.Spec, ToDiagnosticSeverity(declaredReference.Severity));
+                    if (!packageSeverities.ContainsKey(declaredReference.Spec))
+                    {
+                        packageSeverities.Add(declaredReference.Spec, ToDiagnosticSeverity(declaredReference.Severity));
+                    }
                     break;
                 }
             }
@@ -1209,7 +1212,10 @@ public class ReferenceTrimmerAnalyzer : DiagnosticAnalyzer
 
             string assemblyPath = sourceText.ToString(TextSpan.FromBounds(start, firstTab));
             string spec = sourceText.ToString(TextSpan.FromBounds(secondTab + 1, thirdTab));
-            Enum.TryParse<ReferenceTrimmerSeverity>(sourceText.ToString(TextSpan.FromBounds(thirdTab + 1, end)), out var severity);
+            if (!Enum.TryParse<ReferenceTrimmerSeverity>(sourceText.ToString(TextSpan.FromBounds(thirdTab + 1, end)), out var severity))
+            {
+                continue;
+            }
 
             // Determine kind without allocating a string. The three possible values are
             // "Reference" (len 9), "ProjectReference" (len 16), "PackageReference" (len 16).

--- a/src/Package/build/ReferenceTrimmer.targets
+++ b/src/Package/build/ReferenceTrimmer.targets
@@ -86,7 +86,8 @@
       NuGetRestoreTargets="$(NuGetRestoreTargets)"
       TargetFrameworkDirectories="$(TargetFrameworkDirectory)"
       IgnorePackageBuildFiles="@(ReferenceTrimmerIgnorePackageBuildFiles)"
-      NuGetPackageRoot="$(NuGetPackageRoot)" />
+      NuGetPackageRoot="$(NuGetPackageRoot)"
+      EnableReferenceTrimmerDiagnostics="$(EnableReferenceTrimmerDiagnostics)" />
   </Target>
 
   <!--

--- a/src/Shared/DeclaredReferences.cs
+++ b/src/Shared/DeclaredReferences.cs
@@ -1,5 +1,7 @@
 namespace ReferenceTrimmer.Shared;
 
-internal readonly record struct DeclaredReference(string AssemblyPath, DeclaredReferenceKind Kind, string Spec);
+internal readonly record struct DeclaredReference(string AssemblyPath, DeclaredReferenceKind Kind, string Spec, ReferenceTrimmerSeverity Severity);
 
 internal enum DeclaredReferenceKind { Reference, ProjectReference, PackageReference }
+
+internal enum ReferenceTrimmerSeverity { Hidden, Info, Warning }

--- a/src/Shared/DeclaredReferences.cs
+++ b/src/Shared/DeclaredReferences.cs
@@ -4,4 +4,6 @@ internal readonly record struct DeclaredReference(string AssemblyPath, DeclaredR
 
 internal enum DeclaredReferenceKind { Reference, ProjectReference, PackageReference }
 
+// Internal enum to avoid taking a dependency on Microsoft.CodeAnalysis in the Tasks project.
+// The ReferenceTrimmerAnalyzer will convert this to DiagnosticSeverity when reading the declared references file.
 internal enum ReferenceTrimmerSeverity { Hidden, Info, Warning }

--- a/src/Tasks/CollectDeclaredReferencesTask.cs
+++ b/src/Tasks/CollectDeclaredReferencesTask.cs
@@ -53,6 +53,8 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
 
     public string? NuGetPackageRoot { get; set; }
 
+    public string? EnableReferenceTrimmerDiagnostics { get; set; }
+
     public override bool Execute()
     {
         AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
@@ -89,7 +91,8 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                     }
 
                     // Ignore suppressions
-                    if (IsSuppressed(reference, "RT0001"))
+                    var severity = GetReferenceTrimmerSeverity(reference, "RT0001");
+                    if (severity == ReferenceTrimmerSeverity.Hidden)
                     {
                         Log.LogMessage(MessageImportance.Low, "Skipping Reference '{0}' because it is suppressed via NoWarn=\"RT0001\" or <TreatAsUsed>", reference.ItemSpec);
                         continue;
@@ -125,7 +128,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
 
                     if (referencePath is not null)
                     {
-                        declaredReferences.Add(new DeclaredReference(referencePath, DeclaredReferenceKind.Reference, referenceSpec));
+                        declaredReferences.Add(new DeclaredReference(referencePath, DeclaredReferenceKind.Reference, referenceSpec, severity));
                     }
                 }
             }
@@ -139,7 +142,8 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                 foreach (ITaskItem projectReference in ProjectReferences)
                 {
                     // Ignore suppressions
-                    if (IsSuppressed(projectReference, "RT0002"))
+                    var severity = GetReferenceTrimmerSeverity(projectReference, "RT0002");
+                    if (severity == ReferenceTrimmerSeverity.Hidden)
                     {
                         Log.LogMessage(MessageImportance.Low, "Skipping ProjectReference '{0}' because it is suppressed via NoWarn=\"RT0002\" or <TreatAsUsed>", projectReference.ItemSpec);
                         continue;
@@ -158,7 +162,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                     string projectReferenceAssemblyPath = Path.GetFullPath(projectReference.ItemSpec);
                     string referenceProjectFile = projectReference.GetMetadata("OriginalProjectReferenceItemSpec");
 
-                    declaredReferences.Add(new DeclaredReference(projectReferenceAssemblyPath, DeclaredReferenceKind.ProjectReference, referenceProjectFile));
+                    declaredReferences.Add(new DeclaredReference(projectReferenceAssemblyPath, DeclaredReferenceKind.ProjectReference, referenceProjectFile, severity));
                 }
             }
             else
@@ -172,7 +176,8 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
                 foreach (ITaskItem packageReference in PackageReferences)
                 {
                     // Ignore suppressions
-                    if (IsSuppressed(packageReference, "RT0003"))
+                    var severity = GetReferenceTrimmerSeverity(packageReference, "RT0003");
+                    if (severity == ReferenceTrimmerSeverity.Hidden)
                     {
                         Log.LogMessage(MessageImportance.Low, "Skipping PackageReference '{0}' because it is suppressed via NoWarn=\"RT0003\" or <TreatAsUsed>", packageReference.ItemSpec);
                         continue;
@@ -197,7 +202,7 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
 
                     foreach (string assemblyPath in packageInfo.CompileTimeAssemblies)
                     {
-                        declaredReferences.Add(new DeclaredReference(assemblyPath, DeclaredReferenceKind.PackageReference, packageReference.ItemSpec));
+                        declaredReferences.Add(new DeclaredReference(assemblyPath, DeclaredReferenceKind.PackageReference, packageReference.ItemSpec, severity));
                     }
                 }
             }
@@ -450,7 +455,9 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
         return null;
     }
 
-    private static bool IsSuppressed(ITaskItem item, string warningId)
+    private bool IsReferenceTrimmerDiagnosticsEnabled() => bool.TrueString.Equals(EnableReferenceTrimmerDiagnostics, StringComparison.OrdinalIgnoreCase);
+
+    private ReferenceTrimmerSeverity GetReferenceTrimmerSeverity(ITaskItem item, string warningId)
     {
         ReadOnlySpan<char> warningIdSpan = warningId.AsSpan();
         ReadOnlySpan<char> remainingNoWarn = item.GetMetadata(NoWarn).AsSpan();
@@ -471,19 +478,19 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
 
             if (currentNoWarn.Trim().Equals(warningIdSpan, StringComparison.OrdinalIgnoreCase))
             {
-                return true;
+                return IsReferenceTrimmerDiagnosticsEnabled() ? ReferenceTrimmerSeverity.Info : ReferenceTrimmerSeverity.Hidden;
             }
         }
 
         if (item.GetMetadata(TreatAsUsed).Equals("True", StringComparison.OrdinalIgnoreCase))
         {
-            return true;
+            return ReferenceTrimmerSeverity.Hidden;
         }
 
-        return false;
+        return ReferenceTrimmerSeverity.Warning;
     }
 
-    // File format: tab-separated fields (AssemblyPath, Kind, Spec), one reference per line.
+    // File format: tab-separated fields (AssemblyPath, Kind, Spec, Severity), one reference per line.
     // Keep in sync with ReadDeclaredReferences in ReferenceTrimmerAnalyzer.cs.
     private static void SaveDeclaredReferences(IReadOnlyList<DeclaredReference> declaredReferences, string filePath)
     {
@@ -504,6 +511,8 @@ public sealed class CollectDeclaredReferencesTask : MSBuildTask
             writer.Write(kindString);
             writer.Write(fieldDelimiter);
             writer.WriteLine(reference.Spec);
+            writer.Write(fieldDelimiter);
+            writer.WriteLine(reference.Severity);
         }
     }
 

--- a/src/Tests/AnalyzerTests.cs
+++ b/src/Tests/AnalyzerTests.cs
@@ -1353,7 +1353,7 @@ public sealed class AnalyzerTests
         foreach (var dep in dependencies)
         {
             references.Add(dep.Reference);
-            tsvLines.Add($"{dep.Path}\t{dep.Kind}\t{dep.Spec}");
+            tsvLines.Add($"{dep.Path}\t{dep.Kind}\t{dep.Spec}\tWarning");
         }
 
         var compilation = CSharpCompilation.Create(

--- a/src/Tests/E2ETests.cs
+++ b/src/Tests/E2ETests.cs
@@ -34,9 +34,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UsedProjectReference(bool useSymbolAnalysis)
+    public async Task UsedProjectReference(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -45,9 +45,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UsedProjectReferenceProduceReferenceAssembly(bool useSymbolAnalysis)
+    public async Task UsedProjectReferenceProduceReferenceAssembly(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -56,9 +56,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UsedProjectReferenceNoReferenceAssembly(bool useSymbolAnalysis)
+    public async Task UsedProjectReferenceNoReferenceAssembly(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -67,21 +67,21 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UsedProjectReferenceSwitchPattern(bool useSymbolAnalysis)
+    public async Task UsedProjectReferenceSwitchPattern(bool useSymbolAnalysis)
     {
         // Dependency type used only in switch expression type pattern and switch case clause pattern.
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
     }
 
     [TestMethod]
-    public Task UsedProjectReferenceNameof()
+    public async Task UsedProjectReferenceNameof()
     {
         // Dependency type used only in nameof(). nameof is lowered to a string literal
         // in IOperation, so only the syntax-level handler catches it. Symbol-analysis only.
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: true);
@@ -90,11 +90,11 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UsedProjectReferenceCref(bool useSymbolAnalysis)
+    public async Task UsedProjectReferenceCref(bool useSymbolAnalysis)
     {
         // Dependency type used only in XML doc <see cref="..."/>.
         // Both legacy (GetUsedAssemblyReferences with doc mode on) and symbol-based paths handle this.
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -105,9 +105,9 @@ public sealed class E2ETests
     [DataRow(false, false)]
     [DataRow(true, true)]
     [DataRow(false, true)]
-    public Task UnusedProjectReference(bool enableReferenceTrimmerDiagnostics, bool useSymbolAnalysis)
+    public async Task UnusedProjectReference(bool enableReferenceTrimmerDiagnostics, bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: new[]
             {
@@ -120,9 +120,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedProjectReferenceProduceReferenceAssembly(bool useSymbolAnalysis)
+    public async Task UnusedProjectReferenceProduceReferenceAssembly(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: new[]
             {
@@ -134,9 +134,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedProjectReferenceNoReferenceAssembly(bool useSymbolAnalysis)
+    public async Task UnusedProjectReferenceNoReferenceAssembly(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: new[]
             {
@@ -148,9 +148,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedProjectReferenceNoWarn(bool useSymbolAnalysis)
+    public async Task UnusedProjectReferenceNoWarn(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -159,9 +159,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedProjectReferenceTreatAsUsed(bool useSymbolAnalysis)
+    public async Task UnusedProjectReferenceTreatAsUsed(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: Array.Empty<Warning>(),
             useSymbolAnalysis: useSymbolAnalysis);
@@ -170,9 +170,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedProjectReferenceSuppressed(bool useSymbolAnalysis)
+    public async Task UnusedProjectReferenceSuppressed(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -181,9 +181,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedTransitiveProjectReference(bool useSymbolAnalysis)
+    public async Task UnusedTransitiveProjectReference(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: new[]
             {
@@ -196,9 +196,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedDirectAndTransitiveProjectReference(bool useSymbolAnalysis)
+    public async Task UnusedDirectAndTransitiveProjectReference(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: new[]
             {
@@ -210,13 +210,13 @@ public sealed class E2ETests
     }
 
     [TestMethod]
-    public Task UnusedDirectReferenceUsedTransitively()
+    public async Task UnusedDirectReferenceUsedTransitively()
     {
         // Library directly references TransitiveDependency but doesn't use it.
         // Dependency uses TransitiveDependency. Symbol-based analysis is required to
         // reliably detect this as unused — the default approach may or may not depending
         // on whether reference assemblies strip the transitive metadata.
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: new[]
             {
@@ -398,9 +398,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UsedPackageReference(bool useSymbolAnalysis)
+    public async Task UsedPackageReference(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -409,9 +409,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UsedIndirectPackageReference(bool useSymbolAnalysis)
+    public async Task UsedIndirectPackageReference(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "WebHost/WebHost.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -420,9 +420,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedPackageReference(bool useSymbolAnalysis)
+    public async Task UnusedPackageReference(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: new[]
             {
@@ -434,12 +434,12 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedPackageReferenceDocDisabled(bool useSymbolAnalysis)
+    public async Task UnusedPackageReferenceDocDisabled(bool useSymbolAnalysis)
     {
         // Default: RT0000 fires (doc generation disabled warning); the unused package is not detected
         //          because GetUsedAssemblyReferences is less accurate without doc generation.
         // Symbol analysis: RT0003 fires (unused package correctly detected regardless of doc mode).
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: useSymbolAnalysis
                 ? new[] { new Warning("RT0003: PackageReference Newtonsoft.Json can be removed", "Library/Library.csproj") }
@@ -450,9 +450,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedPackageReferenceNoWarn(bool useSymbolAnalysis)
+    public async Task UnusedPackageReferenceNoWarn(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -461,9 +461,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task UnusedPackageReferenceTreatAsUsed(bool useSymbolAnalysis)
+    public async Task UnusedPackageReferenceTreatAsUsed(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -472,9 +472,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task BuildPackageReference(bool useSymbolAnalysis)
+    public async Task BuildPackageReference(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -483,9 +483,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task MissingReferenceSourceTarget(bool useSymbolAnalysis)
+    public async Task MissingReferenceSourceTarget(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -494,9 +494,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task PlatformPackageConflictResolution(bool useSymbolAnalysis)
+    public async Task PlatformPackageConflictResolution(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: new[]
             {
@@ -509,9 +509,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task NoTargets(bool useSymbolAnalysis)
+    public async Task NoTargets(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Project.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -520,9 +520,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task TargetFrameworkWithOs(bool useSymbolAnalysis)
+    public async Task TargetFrameworkWithOs(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -531,9 +531,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task AbsoluteIntermediateOutputPath(bool useSymbolAnalysis)
+    public async Task AbsoluteIntermediateOutputPath(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -542,9 +542,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task BuildExtensions(bool useSymbolAnalysis)
+    public async Task BuildExtensions(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -553,9 +553,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task ReferenceInPackage(bool useSymbolAnalysis)
+    public async Task ReferenceInPackage(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Tests/Tests.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -564,9 +564,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task ReferenceTrimmerDisabled(bool useSymbolAnalysis)
+    public async Task ReferenceTrimmerDisabled(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -640,9 +640,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task WpfApp(bool useSymbolAnalysis)
+    public async Task WpfApp(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "WpfApp/WpfApp.csproj",
             expectedWarnings: [],
             useSymbolAnalysis: useSymbolAnalysis);
@@ -651,9 +651,9 @@ public sealed class E2ETests
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public Task PackageReferenceWithFakeBuildFile(bool useSymbolAnalysis)
+    public async Task PackageReferenceWithFakeBuildFile(bool useSymbolAnalysis)
     {
-        return RunMSBuildAsync(
+        await RunMSBuildAsync(
             projectFile: "Library/Library.csproj",
             expectedWarnings:
             [


### PR DESCRIPTION
Proposal: when `EnableReferenceTrimmerDiagnostics` is enabled, `NoWarn="RT000x"` will emit Informational reports about unused dependencies. The purpose is to allow gradual enforcement of ReferenceTrimmer on a mono-repo and still collect silent telemetry about not-yet-enforced projects.