### PR TITLE
Process MSVC logger events on the primary node

### DIFF
--- a/src/Loggers/MSVC/CentralLogger.cs
+++ b/src/Loggers/MSVC/CentralLogger.cs
@@ -8,8 +8,29 @@ namespace ReferenceTrimmer.Loggers.MSVC;
 /// </summary>
 public sealed class CentralLogger : Logger
 {
+    private sealed class LocalEventRedirector : IEventRedirector
+    {
+        private readonly Action<CustomBuildEventArgs> _forwardEvent;
+
+        public LocalEventRedirector(Action<CustomBuildEventArgs> forwardEvent)
+        {
+            _forwardEvent = forwardEvent;
+        }
+
+        public void ForwardEvent(BuildEventArgs buildEvent)
+        {
+            if (buildEvent is not CustomBuildEventArgs customBuildEvent)
+            {
+                throw new LoggerException($"Unexpected local forwarding event type: {buildEvent.GetType().FullName}");
+            }
+
+            _forwardEvent(customBuildEvent);
+        }
+    }
+
     private readonly object _jsonLogWriteLock = new();
     private Lazy<StreamWriter>? _lazyJsonLogFileStreamWriter;
+    private ForwardingLogger? _localForwardingLogger;
     private bool _firstEvent = true;
     private string? _jsonLogFilePath;
 
@@ -42,11 +63,21 @@ public sealed class CentralLogger : Logger
         });
 
         eventSource.CustomEventRaised += CustomEventHandler;
+
+        _localForwardingLogger = new ForwardingLogger
+        {
+            BuildEventRedirector = new LocalEventRedirector(e => CustomEventHandler(this, e)),
+            Parameters = Parameters,
+            Verbosity = Verbosity,
+        };
+        _localForwardingLogger.Initialize(eventSource);
     }
 
     /// <inheritdoc />
     public override void Shutdown()
     {
+        _localForwardingLogger?.Shutdown();
+
         lock (_jsonLogWriteLock)
         {
             if (_lazyJsonLogFileStreamWriter is not null && _lazyJsonLogFileStreamWriter.IsValueCreated)

--- a/src/Loggers/MSVC/ForwardingLogger.cs
+++ b/src/Loggers/MSVC/ForwardingLogger.cs
@@ -46,11 +46,18 @@ public sealed class ForwardingLogger : IForwardingLogger
 
     private sealed class ProjectStateLibs
     {
+        public ProjectStateLibs(string projectFilePath)
+        {
+            ProjectFilePath = projectFilePath;
+        }
+
+        public string ProjectFilePath { get; }
         public State ProjectState { get; set; }
         public SortedSet<string> UnusedProjectLibPaths { get; } = new(StringComparer.OrdinalIgnoreCase);
     }
 
     private IEventSource? _eventSource;
+    private readonly ConcurrentDictionary<(int NodeId, int ProjectContextId), ProjectStateLibs> _buildContexts = new();
     private readonly ConcurrentDictionary<string, ProjectStateLibs> _projects = new(StringComparer.OrdinalIgnoreCase);
 
     public const string HelpKeyword = "ReferenceTrimmerUnusedMSVCLibraries";
@@ -114,26 +121,38 @@ public sealed class ForwardingLogger : IForwardingLogger
 
     private void OnTaskStarted(object sender, TaskStartedEventArgs e)
     {
-        if (!string.IsNullOrEmpty(e.ProjectFile) && e.TaskName.Equals(LinkTaskName, StringComparison.OrdinalIgnoreCase))
+        string? projectFilePath = e.ProjectFile;
+        if (!string.IsNullOrEmpty(projectFilePath) && e.TaskName.Equals(LinkTaskName, StringComparison.OrdinalIgnoreCase))
         {
-            _projects[e.ProjectFile] = new ProjectStateLibs { ProjectState = State.LinkStarted };
+            var projectState = new ProjectStateLibs(projectFilePath)
+            {
+                ProjectState = State.LinkStarted,
+            };
+
+            if (TryGetProjectContextKey(e, out (int NodeId, int ProjectContextId) projectContextKey))
+            {
+                _buildContexts[projectContextKey] = projectState;
+            }
+            else
+            {
+                _projects[projectFilePath] = projectState;
+            }
         }
     }
 
     private void OnTaskFinished(object sender, TaskFinishedEventArgs e)
     {
-        if (string.IsNullOrEmpty(e.ProjectFile) || e.TaskName != LinkTaskName || !e.Succeeded)
+        if (!e.TaskName.Equals(LinkTaskName, StringComparison.OrdinalIgnoreCase) || !e.Succeeded)
         {
             return;
         }
 
-        string projectFilePath = e.ProjectFile;
-
-        // Project state present in map if the Link task was detected running in OnTaskStarted.
-        if (!_projects.TryGetValue(projectFilePath, out ProjectStateLibs projState))
+        if (!TryGetProjectState(e, e.ProjectFile, out ProjectStateLibs projState))
         {
             return;
         }
+
+        string projectFilePath = projState.ProjectFilePath;
 
         if (projState.ProjectState is State.UnusedLibsStarted or State.UnusedLibsEnded &&
             projState.UnusedProjectLibPaths.Count > 0)
@@ -219,7 +238,7 @@ public sealed class ForwardingLogger : IForwardingLogger
                     jsonSb.ToString()));
         }
 
-        _projects.TryRemove(projectFilePath, out _);
+        RemoveProjectState(e, projectFilePath);
     }
 
     private static string EscapeJsonChars(string str)
@@ -229,15 +248,14 @@ public sealed class ForwardingLogger : IForwardingLogger
 
     private void OnMessageRaised(object sender, BuildMessageEventArgs e)
     {
-        string? projectFilePath = e.ProjectFile;
         string? message = e.Message;
 
-        if (string.IsNullOrEmpty(projectFilePath) || message is null)
+        if (message is null)
         {
             return;
         }
 
-        if (!_projects.TryGetValue(projectFilePath, out ProjectStateLibs? projState))
+        if (!TryGetProjectState(e, e.ProjectFile, out ProjectStateLibs projState))
         {
             return;
         }
@@ -279,5 +297,50 @@ public sealed class ForwardingLogger : IForwardingLogger
             default:
                 break;
         }
+    }
+
+    private bool TryGetProjectState(BuildEventArgs e, string? projectFilePath, out ProjectStateLibs projectState)
+    {
+        if (TryGetProjectContextKey(e, out (int NodeId, int ProjectContextId) projectContextKey))
+        {
+            return _buildContexts.TryGetValue(projectContextKey, out projectState!);
+        }
+
+        if (projectFilePath is { Length: > 0 })
+        {
+            return _projects.TryGetValue(projectFilePath, out projectState!);
+        }
+
+        projectState = null!;
+        return false;
+    }
+
+    private void RemoveProjectState(BuildEventArgs e, string projectFilePath)
+    {
+        if (TryGetProjectContextKey(e, out (int NodeId, int ProjectContextId) projectContextKey))
+        {
+            _buildContexts.TryRemove(projectContextKey, out _);
+        }
+        else
+        {
+            _projects.TryRemove(projectFilePath, out _);
+        }
+    }
+
+    private static bool TryGetProjectContextKey(
+        BuildEventArgs e,
+        out (int NodeId, int ProjectContextId) projectContextKey)
+    {
+        BuildEventContext? context = e.BuildEventContext;
+        if (context is not null &&
+            context.NodeId != BuildEventContext.InvalidNodeId &&
+            context.ProjectContextId != BuildEventContext.InvalidProjectContextId)
+        {
+            projectContextKey = (context.NodeId, context.ProjectContextId);
+            return true;
+        }
+
+        projectContextKey = default;
+        return false;
     }
 }

--- a/src/Tests/MsvcLoggerTests.cs
+++ b/src/Tests/MsvcLoggerTests.cs
@@ -194,6 +194,84 @@ public sealed class MsvcLoggerTests
     }
 
     [TestMethod]
+    public void ForwardingLogger_IsolatesConcurrentBuildContextsForSameProject()
+    {
+        var eventSource = new MockEventSource();
+        var eventRedirector = new MockEventRedirector();
+        var logger = new ForwardingLogger { BuildEventRedirector = eventRedirector };
+        logger.Initialize(eventSource);
+        var firstTaskContext = new BuildEventContext(nodeId: 1, targetId: 2, projectContextId: 3, taskId: 4);
+        var firstMessageContext = new BuildEventContext(nodeId: 1, targetId: 2, projectContextId: 3, taskId: 5);
+        var secondTaskContext = new BuildEventContext(nodeId: 1, targetId: 6, projectContextId: 7, taskId: 8);
+        var secondMessageContext = new BuildEventContext(nodeId: 1, targetId: 6, projectContextId: 7, taskId: 9);
+        try
+        {
+            SendLinkTaskStarted(eventSource, "same.proj", firstTaskContext);
+            SendLinkTaskStarted(eventSource, "same.proj", secondTaskContext);
+            SendLinkMessage(eventSource, "same.proj", "Unused libraries:", firstMessageContext);
+            SendLinkMessage(eventSource, "same.proj", "Unused libraries:", secondMessageContext);
+            SendLinkMessage(eventSource, "same.proj", "  first.lib", firstMessageContext);
+            SendLinkMessage(eventSource, "same.proj", "  second.lib", secondMessageContext);
+            SendLinkTaskFinished(eventSource, string.Empty, firstTaskContext);
+            SendLinkTaskFinished(eventSource, string.Empty, secondTaskContext);
+
+            Assert.HasCount(2, eventRedirector.Events);
+            UnusedLibsCustomBuildEventArgs firstEvent = GetUnusedLibEvent(eventRedirector.Events[0]);
+            UnusedLibsCustomBuildEventArgs secondEvent = GetUnusedLibEvent(eventRedirector.Events[1]);
+            Assert.Contains("first.lib", firstEvent.UnusedLibraryPathsJson);
+            Assert.IsFalse(firstEvent.UnusedLibraryPathsJson.Contains("second.lib", StringComparison.Ordinal));
+            Assert.Contains("second.lib", secondEvent.UnusedLibraryPathsJson);
+            Assert.IsFalse(secondEvent.UnusedLibraryPathsJson.Contains("first.lib", StringComparison.Ordinal));
+        }
+        finally
+        {
+            logger.Shutdown();
+        }
+    }
+
+    [TestMethod]
+    public void ForwardingLogger_FallsBackToProjectPathForPartialBuildContexts()
+    {
+        var eventSource = new MockEventSource();
+        var eventRedirector = new MockEventRedirector();
+        var logger = new ForwardingLogger { BuildEventRedirector = eventRedirector };
+        logger.Initialize(eventSource);
+        var firstContext = new BuildEventContext(
+            nodeId: 1,
+            targetId: 2,
+            projectContextId: BuildEventContext.InvalidProjectContextId,
+            taskId: 3);
+        var secondContext = new BuildEventContext(
+            nodeId: 1,
+            targetId: 4,
+            projectContextId: BuildEventContext.InvalidProjectContextId,
+            taskId: 5);
+        try
+        {
+            SendLinkTaskStarted(eventSource, "first.proj", firstContext);
+            SendLinkTaskStarted(eventSource, "second.proj", secondContext);
+            SendLinkMessage(eventSource, "first.proj", "Unused libraries:", firstContext);
+            SendLinkMessage(eventSource, "second.proj", "Unused libraries:", secondContext);
+            SendLinkMessage(eventSource, "first.proj", "  first.lib", firstContext);
+            SendLinkMessage(eventSource, "second.proj", "  second.lib", secondContext);
+            SendLinkTaskFinished(eventSource, "first.proj", firstContext);
+            SendLinkTaskFinished(eventSource, "second.proj", secondContext);
+
+            Assert.HasCount(2, eventRedirector.Events);
+            UnusedLibsCustomBuildEventArgs firstEvent = GetUnusedLibEvent(eventRedirector.Events[0]);
+            UnusedLibsCustomBuildEventArgs secondEvent = GetUnusedLibEvent(eventRedirector.Events[1]);
+            Assert.Contains("first.lib", firstEvent.UnusedLibraryPathsJson);
+            Assert.IsFalse(firstEvent.UnusedLibraryPathsJson.Contains("second.lib", StringComparison.Ordinal));
+            Assert.Contains("second.lib", secondEvent.UnusedLibraryPathsJson);
+            Assert.IsFalse(secondEvent.UnusedLibraryPathsJson.Contains("first.lib", StringComparison.Ordinal));
+        }
+        finally
+        {
+            logger.Shutdown();
+        }
+    }
+
+    [TestMethod]
     public void ForwardingLogger_ForwardsNothingIfLinkTaskFails()
     {
         var eventSource = new MockEventSource();
@@ -241,6 +319,65 @@ public sealed class MsvcLoggerTests
 
     [TestMethod]
     [DoNotParallelize]
+    public async Task CentralLogger_ProcessesUnusedLibEventsFromPrimaryNode()
+    {
+        string jsonPath = Path.Combine(Environment.CurrentDirectory, CentralLogger.JsonLogFileName);
+        DeleteIfExists(jsonPath);
+
+        var eventSource = new MockEventSource();
+        var centralLogger = new CentralLogger();
+        centralLogger.Initialize(eventSource);
+        eventSource.AssertExpectedCentralLoggerEventSubscriptions();
+        eventSource.AssertExpectedForwardingEventSubscriptions();
+        eventSource.SendTaskStarted(new TaskStartedEventArgs(
+            message: "Link starting",
+            helpKeyword: "Link",
+            projectFile: "a.proj",
+            taskFile: "a.proj",
+            taskName: "Link"));
+        eventSource.SendMessageRaised(new BuildMessageEventArgs(
+            message: "Unused libraries:",
+            helpKeyword: "Link",
+            senderName: "Link",
+            MessageImportance.High,
+            DateTime.Now)
+        {
+            ProjectFile = "a.proj",
+        });
+        eventSource.SendMessageRaised(new BuildMessageEventArgs(
+            message: "  user32.lib",
+            helpKeyword: "Link",
+            senderName: "Link",
+            MessageImportance.High,
+            DateTime.Now)
+        {
+            ProjectFile = "a.proj",
+        });
+        eventSource.SendMessageRaised(new BuildMessageEventArgs(
+            message: string.Empty,
+            helpKeyword: "Link",
+            senderName: "Link",
+            MessageImportance.High,
+            DateTime.Now)
+        {
+            ProjectFile = "a.proj",
+        });
+        eventSource.SendTaskFinished(new TaskFinishedEventArgs(
+            message: "Link finished",
+            helpKeyword: "Link",
+            projectFile: "a.proj",
+            taskFile: "a.proj",
+            taskName: "Link",
+            succeeded: true));
+        centralLogger.Shutdown();
+
+        Assert.IsTrue(File.Exists(jsonPath));
+        string json = await File.ReadAllTextAsync(jsonPath);
+        Assert.Contains("user32.lib", json);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
     public async Task CentralLogger_JsonOnUnusedLibEvents()
     {
         string jsonPath = Path.Combine(Environment.CurrentDirectory, CentralLogger.JsonLogFileName);
@@ -258,6 +395,64 @@ public sealed class MsvcLoggerTests
         Assert.IsTrue(File.Exists(jsonPath));
         Assert.AreEqual($"[{Environment.NewLine}{{ \"aProp\": \"aValue\" }},{Environment.NewLine}{{ \"aProp2\": \"aValue2\" }}{Environment.NewLine}]{Environment.NewLine}",
             await File.ReadAllTextAsync(jsonPath));
+    }
+
+    private static void SendLinkTaskStarted(
+        MockEventSource eventSource,
+        string projectFile,
+        BuildEventContext context)
+    {
+        eventSource.SendTaskStarted(new TaskStartedEventArgs(
+            message: "Link starting",
+            helpKeyword: "Link",
+            projectFile: projectFile,
+            taskFile: projectFile,
+            taskName: "Link")
+        {
+            BuildEventContext = context,
+        });
+    }
+
+    private static void SendLinkMessage(
+        MockEventSource eventSource,
+        string projectFile,
+        string message,
+        BuildEventContext context)
+    {
+        eventSource.SendMessageRaised(new BuildMessageEventArgs(
+            message: message,
+            helpKeyword: "Link",
+            senderName: "Link",
+            MessageImportance.High,
+            DateTime.Now)
+        {
+            BuildEventContext = context,
+            ProjectFile = projectFile,
+        });
+    }
+
+    private static void SendLinkTaskFinished(
+        MockEventSource eventSource,
+        string projectFile,
+        BuildEventContext context)
+    {
+        eventSource.SendTaskFinished(new TaskFinishedEventArgs(
+            message: "Link finished",
+            helpKeyword: "Link",
+            projectFile: projectFile,
+            taskFile: projectFile,
+            taskName: "Link",
+            succeeded: true)
+        {
+            BuildEventContext = context,
+        });
+    }
+
+    private static UnusedLibsCustomBuildEventArgs GetUnusedLibEvent(BuildEventArgs buildEvent)
+    {
+        var unusedLibEvent = buildEvent as UnusedLibsCustomBuildEventArgs;
+        Assert.IsNotNull(unusedLibEvent);
+        return unusedLibEvent;
     }
 
     private static void DeleteIfExists(string path)


### PR DESCRIPTION
## Summary

Handle the central node's `Unused libraries:` output directly when no secondary node exists. This preserves `ReferenceTrimmerUnusedMSVCLibraries.json.log` generation for `/m:1` and covers `/m:N` builds that execute link tasks on the central node.

The change also tightens context correlation so concurrent builds for the same project path do not cross-contaminate each other, while still falling back safely when MSBuild only provides partial context.

## Why this is safe

- Scope is limited to MSVC logger event handling and associated tests.
- Existing forwarding behavior is preserved; the fix only adds a central-node path and more precise build-context matching.
- Partial/invalid context still falls back to project path, avoiding regressions when MSBuild omits identifiers.

## Testing

| Test / build | Result |
|---|---|
| GitHub Actions run `31820717422` at `2fefc29ea7b133fa1323aa56705c1a5636fb7a7b` | Passed |
| Restore, build, and test suite | Passed (175/175 tests) |
| Notable coverage | `ForwardingLogger_IsolatesConcurrentBuildContextsForSameProject`, `ForwardingLogger_FallsBackToProjectPathForPartialBuildContexts`, `CentralLogger_ProcessesUnusedLibEventsFromPrimaryNode`, `UnusedWinSdkImportLibrary`, `UnusedCppLibrary`, `UnusedCppDelayLoadLibrary` |